### PR TITLE
fx (foreign exchange) rate provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1101,15 +1101,112 @@ dependencies = [
 
 [[package]]
 name = "bss-ledger-sdk"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "async-trait",
  "cf-gears-toolkit-canonical-errors",
+ "cf-gears-toolkit-gts",
  "cf-gears-toolkit-odata",
  "cf-gears-toolkit-security",
  "chrono",
+ "gts",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
  "thiserror 2.0.18",
  "uuid",
+]
+
+[[package]]
+name = "bss-rate-provider"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bss-ledger-sdk",
+ "bss-rate-provider-sdk",
+ "cf-gears-toolkit",
+ "cf-gears-toolkit-macros",
+ "cf-gears-toolkit-security",
+ "cf-gears-types-registry",
+ "cf-gears-types-registry-sdk",
+ "chrono",
+ "inventory",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "bss-rate-provider-ecb-plugin"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "axum",
+ "bss-ledger-sdk",
+ "bss-rate-provider-sdk",
+ "cf-gears-toolkit",
+ "cf-gears-toolkit-http",
+ "cf-gears-toolkit-security",
+ "cf-gears-types-registry",
+ "chrono",
+ "inventory",
+ "quick-xml 0.41.0",
+ "serde",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "bss-rate-provider-http-json-plugin"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "axum",
+ "bss-ledger-sdk",
+ "bss-rate-provider-sdk",
+ "cf-gears-toolkit",
+ "cf-gears-toolkit-http",
+ "cf-gears-toolkit-security",
+ "cf-gears-types-registry",
+ "chrono",
+ "inventory",
+ "secrecy",
+ "serde",
+ "serde-saphyr 0.0.22",
+ "serde_json",
+ "temp-env",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "bss-rate-provider-sdk"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "bss-ledger-sdk",
+ "cf-gears-toolkit",
+ "cf-gears-toolkit-gts",
+ "cf-gears-toolkit-http",
+ "cf-gears-types-registry-sdk",
+ "chrono",
+ "gts",
+ "http",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "rust_decimal",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1802,6 +1899,9 @@ version = "0.6.1"
 dependencies = [
  "anyhow",
  "bss-ledger",
+ "bss-rate-provider",
+ "bss-rate-provider-ecb-plugin",
+ "bss-rate-provider-http-json-plugin",
  "calculator",
  "calculator-gateway",
  "cf-chat-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,10 @@ members = [
     "gears/llm-gateway/llm-gateway-sdk",
     "gears/bss/ledger/ledger",
     "gears/bss/ledger/ledger-sdk",
+    "gears/bss/rate-provider/rate-provider-sdk",
+    "gears/bss/rate-provider/rate-provider",
+    "gears/bss/rate-provider/plugins/ecb-plugin",
+    "gears/bss/rate-provider/plugins/http-json-plugin",
     "gears/bss/libs/coord",
     "gears/system/event-broker/event-broker-sdk",
     "gears/system/event-broker/event-broker",
@@ -311,7 +315,8 @@ oagw-sdk = { package = "cf-gears-oagw-sdk", version = "0.5.5", path = "gears/sys
 usage-collector-sdk = { package = "cf-gears-usage-collector-sdk", version = "0.3.2", path = "gears/system/usage-collector/usage-collector-sdk" }
 
 # BSS gears (ported from vhp-core)
-bss-ledger-sdk = { path = "gears/bss/ledger/ledger-sdk" }
+bss-ledger-sdk = { path = "gears/bss/ledger/ledger-sdk", version = "0.1.0" }
+bss-rate-provider-sdk = { path = "gears/bss/rate-provider/rate-provider-sdk", version = "0.1.0" }
 coord = { path = "gears/bss/libs/coord" }
 # FIPS-validated SHA-256 for the ledger idempotency payload fingerprint.
 aws-lc-rs = "1.17"

--- a/apps/cf-gears-example-server/Cargo.toml
+++ b/apps/cf-gears-example-server/Cargo.toml
@@ -30,6 +30,14 @@ otel = ["toolkit/otel"]
 account-management = ["dep:account_management"]
 static-idp = ["dep:static-idp-plugin"]
 file-storage = ["dep:file_storage"]
+# The FX rate-provider subsystem: the core gear + its source plugins. Independent
+# of bss-ledger — the ledger discovers the composite lazily at runtime via the
+# types-registry, so neither feature requires the other.
+bss-rate-provider = [
+    "dep:bss_rate_provider",
+    "dep:bss_rate_provider_ecb_plugin",
+    "dep:bss_rate_provider_http_json_plugin",
+]
 bss-ledger = ["dep:bss_ledger"]
 usage-collector = ["dep:usage_collector"]
 timescaledb-usage-collector = ["dep:timescaledb_usage_collector_plugin"]
@@ -87,6 +95,9 @@ static-idp-plugin = { package = "cf-gears-static-idp-plugin", path = "../../gear
 
 # Optional BSS Billing Ledger gear
 bss_ledger = { package = "bss-ledger", path = "../../gears/bss/ledger/ledger", optional = true }
+bss_rate_provider = { package = "bss-rate-provider", path = "../../gears/bss/rate-provider/rate-provider", optional = true }
+bss_rate_provider_ecb_plugin = { package = "bss-rate-provider-ecb-plugin", path = "../../gears/bss/rate-provider/plugins/ecb-plugin", optional = true }
+bss_rate_provider_http_json_plugin = { package = "bss-rate-provider-http-json-plugin", path = "../../gears/bss/rate-provider/plugins/http-json-plugin", optional = true }
 
 # Optional Usage Collector gear + its TimescaleDB storage plugin
 usage_collector = { package = "cf-gears-usage-collector", path = "../../gears/system/usage-collector/usage-collector", optional = true }

--- a/apps/cf-gears-example-server/src/registered_gears.rs
+++ b/apps/cf-gears-example-server/src/registered_gears.rs
@@ -74,6 +74,13 @@ use static_idp_plugin as _;
 #[cfg(feature = "account-management")]
 use account_management as _;
 
+#[cfg(feature = "bss-rate-provider")]
+use bss_rate_provider as _;
+#[cfg(feature = "bss-rate-provider")]
+use bss_rate_provider_ecb_plugin as _;
+#[cfg(feature = "bss-rate-provider")]
+use bss_rate_provider_http_json_plugin as _;
+
 #[cfg(feature = "bss-ledger")]
 use bss_ledger as _;
 

--- a/config/e2e-local.yaml
+++ b/config/e2e-local.yaml
@@ -377,11 +377,45 @@ gears:
         # rather than silently shipping a half-wired stack.
         required: true
 
+  # FX rate-provider subsystem (plugin-based): the core `bss-rate-provider` gear
+  # discovers + composes source plugins; the ledger discovers the composite LAZILY
+  # from the types-registry each rate-sync tick (no deps edge). Compiled via the
+  # server `bss-rate-provider` feature. LEFT UNCONFIGURED here on purpose: an active
+  # ECB plugin makes the ledger's RateSyncJob fetch the LIVE ECB feed on its first
+  # tick (network egress in E2E). Enable in a deployment (or a gated FX E2E with a
+  # mock server) by uncommenting all sections; keep the vendors aligned across the
+  # core gear, the source plugins, and the ledger's `fx.provider_vendor`:
+  #
+  # bss-rate-provider:                 # core gear: discover source plugins + compose
+  #   config:
+  #     vendor: cf.bss                 # advertised to the ledger's fx.provider_vendor
+  #     source_vendor: cf.bss          # selects which source plugins to compose
+  # bss-rate-provider-ecb-plugin:      # ECB source plugin (primary; priority 100)
+  #   config:
+  #     id: ecb
+  #     vendor: cf.bss
+  #     priority: 100
+  #     base_url: "https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml"
+  # # bss-rate-provider-http-json-plugin: add later for a fallback REST feed.
+  #
+  # ...and the consumer side: the `bss-ledger` block below gains an `fx` stanza
+  # naming the vendor the core gear advertises. Spelled out rather than left to
+  # the defaults because all three strings are matched literally and nothing
+  # validates them at startup — a typo in any one of them surfaces only as a
+  # "no source plugins registered" error on the ledger's first rate-sync tick.
+  #
+  # bss-ledger:
+  #   config:
+  #     fx:
+  #       provider_vendor: cf.bss      # MUST equal the core gear's `vendor` above
+  #
   bss-ledger:
     # Gear-specific database (SQLite for E2E, like the other user gears; the
     # gear ships dual PG/SQLite migrations). No config block needed — the
     # defaults (events_enabled=false, seller_tenant_types=partner+platform)
-    # are correct for E2E.
+    # are correct for E2E. `fx.provider_vendor` also defaults to "cf.bss", the
+    # same default the core `bss-rate-provider` gear advertises as its `vendor`,
+    # so the commented FX example above lines up without further edits.
     database:
       server: "sqlite_users"
       file: "bss_ledger.db"

--- a/gears/bss/ledger/docs/design/06-fx-multicurrency.md
+++ b/gears/bss/ledger/docs/design/06-fx-multicurrency.md
@@ -427,12 +427,53 @@ The system **MUST** lock exactly one functional rate per entry at the defined lo
 
 The system **MUST** acquire rates via the background sync job into a local rates store (no synchronous provider call on the posting path), resolve deterministically over the tenant-configured provider list with recorded `fallback_order`, enforce the F3 staleness thresholds (G10 24 h; others ≤ 7 d, over-7-d config rejected), block with `FX_RATE_UNAVAILABLE`/`FX_RATE_STALE_NOT_ALLOWED` per policy, mark allowed fallbacks `stale=true`, and handle ECB non-publication dates + EUR triangulation on the snapshot.
 
+The sync job **MUST** also be **observably alive**, independently of whether any fetch
+succeeds or fails. A stalled ticker is not a provider failure: it attempts no fetch, so it
+produces no fetch error, raises no `fx-snapshot-missing` alarm, and leaves the rate store
+quietly ageing until an unrelated post blocks on staleness — up to the F3 window (24 h for
+G10). Liveness is therefore alerted on the **absence of ticks**, never on errors:
+
+| Alert | Condition | Owner | Rationale |
+|-------|-----------|-------|-----------|
+| `FxRateSyncStalled` | `increase(ledger_fx_rate_sync_ticks_total[3 × fx.rate_sync_tick_secs]) == 0` | Platform on-call (job liveness) | "The scheduler is not ticking at all". Three missed ticks tolerate one transient stall without paging; at the 3600 s default that fires ~3 h in, well inside the 24 h G10 staleness window, so it precedes any `FX_RATE_UNAVAILABLE` post failure. |
+| `FxRateSyncNeverRan` | `ledger_fx_rate_sync_ticks_total` absent for a deployment with a configured provider | Platform on-call (job liveness) | The fresh-deploy failure mode. An `increase()` over a missing series never fires, so absence must be alerted separately. |
+| `FxRateSyncOverrunning` | `histogram_quantile(0.95, rate(ledger_fx_rate_sync_duration_seconds_bucket[24h])) > 0.5 × fx.rate_sync_tick_secs` | Platform on-call (job liveness) | A pass that grows past its own interval delays the next one, so refreshes thin out. `FxRateSyncStalled` catches this only once a pass exceeds 3 × the interval — by then refreshes are already being starved. Warn, not page: half the interval is a trend signal with room to act, and the fail-safe below still holds meanwhile. |
+
+`ledger_fx_rate_sync_ticks_total` counts **ticks, not fetches**, and is unlabelled — the tick
+is counted before any provider is resolved, so there is no provider identity to attribute it
+to. Read together with the adapter's own `fx_provider_fetch_duration_seconds` count it also
+separates two states that error-based alerting cannot tell apart: a flat heartbeat means the
+ticker is dead, while a rising heartbeat with a flat fetch count means the job is alive but
+discovery yields no sources (a `vendor` typo, an unavailable types-registry, no source plugin
+registered). Feed freshness is a **separate** concern with a separate threshold set by the
+feed's publication cadence — see the rate-provider adapter's DESIGN § "Feature metrics".
+
+`ledger_fx_rate_sync_duration_seconds` is the heartbeat's companion: the wall time of one
+pass, discovery and every source attempt included, recorded whether the pass succeeded or
+failed. It exists because the heartbeat answers "is the job running" but not "is it keeping
+up" — and the adapter's per-source `fx_provider_fetch_duration_seconds` cannot answer that
+either, since the composite tries its sources **sequentially**, so a pass costs their sum.
+The pass is what must fit inside `fx.rate_sync_tick_secs`; this is the only series that
+measures it. Also unlabelled, for the same reason as the heartbeat.
+
+**Acceptance test.** With a configured provider, stop the rate-sync ticker and assert that
+`ledger_fx_rate_sync_ticks_total` stops increasing while no fetch error is recorded and no
+`fx-snapshot-missing` alarm is raised — i.e. that the stall is invisible to error-based
+alerting and only the no-tick condition catches it. Assert separately that the adapter's
+`fx_provider_last_success_timestamp` alone would NOT have caught it, since it can read
+arbitrarily stale on a healthy feed between publications. Separately, with a source that
+takes longer than the configured interval to answer, assert that
+`ledger_fx_rate_sync_duration_seconds` records a sample above `fx.rate_sync_tick_secs` while
+the heartbeat keeps rising — the overrun state the tick counter alone cannot express.
+
 **Implements**:
 - `cpt-cf-bss-ledger-algo-fx-rate-source-fallback`
 
 **Touches**:
 - DB: local rates store, `rate_snapshot`
 - Entities: `RateSnapshot`, `RateSource`
+- Metrics: `ledger_fx_rate_sync_ticks_total` (job-liveness heartbeat),
+  `ledger_fx_rate_sync_duration_seconds` (whole-pass latency, read against the tick interval)
 
 ### Realized FX Posting
 
@@ -513,7 +554,7 @@ NFR verification:
 
 - **Performance / NFR mapping**: Inherits Slice 1 targets (e.g. write p95 ≤ 500 ms — the Foundation NFR mapping). Slice-5-specific: missing FX snapshot **blocks** the post (Critical); stale-allowed is Warn; stale-not-allowed blocks (422) (AC #18). FX adds at most one functional-only line per entry → negligible latency impact on the inherited write-p95 target. Traces to `cpt-cf-bss-ledger-nfr-posting-performance`.
 - **Security & AuthZ**: Inherits Slice 1: RLS, append-only, PII-minimized events. Triggering revaluation runs requires the finance scope; rate snapshots are read-only references. The ledger trusts the provider feed's authenticity (provider auth is upstream/ops).
-- **Observability / Feature metrics**: `ledger_fx_realized_minor{functional_currency}`, `ledger_fx_snapshot_missing_total`, `ledger_fx_snapshot_stale_allowed_total`, `ledger_fx_snapshot_stale_blocked_total`, `ledger_fx_revaluation_duration_seconds` (— aligned with the `revaluation_completed` event rename), `ledger_fx_provider_fallback_total{provider}`. Thresholds wire to the NFR mapping + the snapshot alarms.
+- **Observability / Feature metrics**: `ledger_fx_realized_minor{functional_currency}`, `ledger_fx_snapshot_missing_total`, `ledger_fx_snapshot_stale_allowed_total`, `ledger_fx_snapshot_stale_blocked_total`, `ledger_fx_revaluation_duration_seconds` (— aligned with the `revaluation_completed` event rename), `ledger_fx_provider_fallback_total{provider}`, `ledger_fx_rate_sync_ticks_total` (the sync-job liveness heartbeat — alerted on absence of ticks, never on errors), `ledger_fx_rate_sync_duration_seconds` (whole-pass latency, alerted against the configured tick interval — see the `FxRateSyncStalled` / `FxRateSyncNeverRan` / `FxRateSyncOverrunning` definitions under the rate-source DoD in §8). Thresholds wire to the NFR mapping + the snapshot alarms.
 - **Risks & deferred work**: **FX provider** — **ratified 2026-06-10: ECB primary, PSP/bank feed fallback**; the snapshot/lock/realized-FX mechanics are stable. The **Foundation's dual-column commit trigger** (functional balance, two checks) + the relaxed `amount_minor` CHECK are Foundation-owned (native, on every leaf partition); this feature posts functional-only lines that exercise them; covered by integration tests. **Deferred:** FX consistency reconciliation vs external rates + ERP FX export → Slice 7; pricing-side FX/rate-lock → Catalog; cross-currency conversion event → deferred post-MVP.
 - **Needs discussion** (inherits Slices 1–4 open items; slice-specific):
 

--- a/gears/bss/ledger/ledger-sdk/Cargo.toml
+++ b/gears/bss/ledger/ledger-sdk/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "bss-ledger-sdk"
+version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 description = "BSS Billing Ledger SDK: infrastructure-free contract for ClientHub consumers"
@@ -22,3 +23,11 @@ toolkit-canonical-errors = { workspace = true }
 toolkit-odata = { workspace = true }
 toolkit-security = { workspace = true }
 uuid = { workspace = true }
+# GTS PluginV1 base + `#[gts_type_schema]` for the rate-provider plugin spec the
+# ledger discovers (`RateProviderPluginSpecV1`).
+toolkit-gts = { workspace = true }
+gts = { workspace = true }
+# `#[gts_type_schema]` expands to `schemars`- + `serde`-derived JSON-schema code.
+schemars = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/gears/bss/ledger/ledger-sdk/src/lib.rs
+++ b/gears/bss/ledger/ledger-sdk/src/lib.rs
@@ -15,6 +15,7 @@ pub mod posting;
 pub mod provisioning;
 pub mod psp_settlement_feed;
 pub mod rate_provider;
+pub mod rate_provider_plugin;
 
 pub use api::LedgerClientV1;
 pub use bill_run_finished::{BillRunFinishedV1, UnconfiguredBillRunFinishedV1};
@@ -46,3 +47,4 @@ pub use psp_settlement_feed::{
 pub use rate_provider::{
     CurrencyPair, ProviderRate, RateProviderError, RateProviderV1, UnconfiguredRateProviderV1,
 };
+pub use rate_provider_plugin::RateProviderPluginSpecV1;

--- a/gears/bss/ledger/ledger-sdk/src/rate_provider.rs
+++ b/gears/bss/ledger/ledger-sdk/src/rate_provider.rs
@@ -20,13 +20,25 @@ pub struct CurrencyPair {
 
 /// A rate as published by a provider at a point in time. `rate_micro` is the
 /// fixed-precision multiplier (functional per unit transaction × 1e6). `as_of`
-/// drives the ledger's staleness rule; the provider id is recorded separately.
+/// drives the ledger's staleness rule.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ProviderRate {
     pub base: String,
     pub quote: String,
     pub rate_micro: i64,
     pub as_of: chrono::DateTime<chrono::Utc>,
+    /// The concrete upstream that published THIS rate (`"ecb"`, `"bank-x"`, …),
+    /// stamped by the serving source itself.
+    ///
+    /// Provenance is per-rate, not per-call. A composite adapter serves one
+    /// whole document from whichever source answered first — it never merges
+    /// rates from several sources — so which upstream supplied a given batch
+    /// varies between calls. An adapter shared by more than one caller therefore
+    /// cannot answer "who served the batch you just fetched?" through a separate
+    /// [`RateProviderV1::provider_id`] call without racing. Recording it on the
+    /// rate keeps `ledger_fx_rate.provider` / `rate_snapshot.provider` truthful
+    /// for audit regardless of call interleaving.
+    pub provider: String,
 }
 
 /// A rate-provider failure. Semantic (the ledger maps it to a sync-job alarm, or
@@ -49,8 +61,16 @@ pub enum RateProviderError {
 /// `ClientHub` by GTS instance. See the module docs.
 #[async_trait]
 pub trait RateProviderV1: Send + Sync {
-    /// Stable id recorded verbatim on every `rate_snapshot.provider`; the
-    /// fallback-order key. E.g. "ecb", "bank-x", "psp-stripe".
+    /// Stable identity of the *adapter* — e.g. `"ecb"` for a single-source
+    /// plugin, or the composite's configured id. E.g. "ecb", "bank-x",
+    /// "psp-stripe"; `"none"` is reserved for
+    /// [`UnconfiguredRateProviderV1`] and means "no adapter wired".
+    ///
+    /// MUST be a constant identity, not "whoever served last": per-rate
+    /// provenance belongs on [`ProviderRate::provider`], because this call
+    /// carries no information about which `fetch_latest` it relates to. Used for
+    /// alarm/log attribution and the unconfigured-sentinel check, never to stamp
+    /// a stored rate.
     fn provider_id(&self) -> &str;
 
     /// Fetch the latest published rates for the requested pairs — one round-trip.
@@ -68,18 +88,47 @@ pub trait RateProviderV1: Send + Sync {
         request_id: &str,
     ) -> Result<Vec<ProviderRate>, RateProviderError>;
 
-    /// Liveness probe for the sync-job reachability alarm. Default = a trivial
-    /// `fetch_latest`; an adapter MAY override with a cheaper ping.
+    /// **Reachability probe only** — "would a request to this provider get
+    /// through right now?", never "would the next fetch produce usable rates?".
+    ///
+    /// ## What counts as reachable
+    ///
+    /// `Ok(())` means **the endpoint answered**. Any HTTP response is an answer,
+    /// including `4xx` and `5xx`: a `503` proves the request arrived, and a `405`
+    /// is a normal reply from a feed that simply does not accept the probe's
+    /// method. Only a *transport* failure — DNS, connect, TLS, timeout — is
+    /// `Err`, because only then did nothing get through.
+    ///
+    /// That line is deliberate. "Reachable" and "serving correctly" are different
+    /// questions, and folding the second into this one would make `Ok(())` mean
+    /// something no cheap probe can actually establish. Reading a non-2xx as
+    /// unhealthy also breaks the probe on feeds that answer a `HEAD` with `405`
+    /// while serving `GET` perfectly.
+    ///
+    /// ## What it does NOT tell you
+    ///
+    /// An adapter can be reachable while every real fetch fails on a malformed,
+    /// empty, or wrongly-shaped body. Feed freshness is a separate signal and
+    /// MUST NOT be inferred from this one: `fx_provider_last_success_timestamp`
+    /// advances only on a fetch that actually parsed, and that gauge — not this
+    /// probe — is what a stalled-feed alert reads.
+    ///
+    /// ## No default implementation, on purpose
+    ///
+    /// There is deliberately no default. A default delegating to `fetch_latest`
+    /// gave adapters that did not override it a *parsing* health check by
+    /// accident, so one method carried two different guarantees depending on the
+    /// vendor, and `Ok(())` could only ever be read as the weakest of them.
+    /// Every adapter now states its own probe, so the contract above is what
+    /// each one implements rather than what it happens to inherit.
     ///
     /// # Errors
-    /// [`RateProviderError`] when the provider is unreachable.
+    /// [`RateProviderError`] when nothing got through to the provider at all.
     async fn health(
         &self,
         ctx: &SecurityContext,
         request_id: &str,
-    ) -> Result<(), RateProviderError> {
-        self.fetch_latest(ctx, &[], request_id).await.map(|_| ())
-    }
+    ) -> Result<(), RateProviderError>;
 }
 
 /// Fail-safe default until a real adapter is wired: every fetch fails, so the
@@ -109,6 +158,19 @@ impl RateProviderV1 for UnconfiguredRateProviderV1 {
         _pairs: &[CurrencyPair],
         _request_id: &str,
     ) -> Result<Vec<ProviderRate>, RateProviderError> {
+        Err(RateProviderError::Unreachable(
+            "no FX rate adapter configured".to_owned(),
+        ))
+    }
+
+    /// Always unreachable: there is no endpoint to probe. This sentinel exists
+    /// precisely because nothing is wired, so reporting reachable would be a
+    /// false green — the one thing the probe must never be.
+    async fn health(
+        &self,
+        _ctx: &SecurityContext,
+        _request_id: &str,
+    ) -> Result<(), RateProviderError> {
         Err(RateProviderError::Unreachable(
             "no FX rate adapter configured".to_owned(),
         ))

--- a/gears/bss/ledger/ledger-sdk/src/rate_provider_plugin.rs
+++ b/gears/bss/ledger/ledger-sdk/src/rate_provider_plugin.rs
@@ -1,0 +1,23 @@
+//! GTS schema for the FX rate-provider *composite* plugin the ledger discovers.
+//!
+//! The external `bss-rate-provider` core gear registers a `PluginV1` instance of
+//! this type in the types-registry (and a scoped [`crate::RateProviderV1`] client
+//! keyed by the instance id). The ledger's `RateSyncJob` discovers it each tick
+//! (`list_instances` + vendor/priority select + `get_scoped`), falling back to
+//! [`crate::UnconfiguredRateProviderV1`] when none is registered.
+
+use toolkit_gts::{PluginV1, gts_type_schema};
+
+/// GTS type for the composite rate-provider plugin instance.
+///
+/// Instance ids look like
+/// `gts.cf.toolkit.plugins.plugin.v1~cf.bss.rate_provider.plugin.v1~<vendor>.<segment>`.
+#[derive(Default)]
+#[gts_type_schema(
+    dir_path = "schemas",
+    base = PluginV1,
+    type_id = gts_id!("cf.toolkit.plugins.plugin.v1~cf.bss.rate_provider.plugin.v1~"),
+    description = "FX rate-provider composite plugin specification",
+    properties = "",
+)]
+pub struct RateProviderPluginSpecV1;

--- a/gears/bss/ledger/ledger/Cargo.toml
+++ b/gears/bss/ledger/ledger/Cargo.toml
@@ -113,6 +113,9 @@ toolkit-db = { workspace = true, features = ["pg", "sqlite"] }
 # crate as a direct dev-dep).
 toolkit-odata = { workspace = true, features = ["with-utoipa"] }
 tokio = { workspace = true }
+# In-memory `MockTypesRegistryClient` for the rate-provider lazy-discovery test
+# (`module_tests.rs` exercising `resolve_rate_provider`).
+types-registry-sdk = { workspace = true, features = ["test-util"] }
 # Postgres testcontainers harness; tests reach `testcontainers` items through
 # the `testcontainers_modules::testcontainers` re-export, so the bare
 # `testcontainers` crate is not a direct dep. Raw SQL in tests goes through

--- a/gears/bss/ledger/ledger/src/config.rs
+++ b/gears/bss/ledger/ledger/src/config.rs
@@ -140,6 +140,13 @@ pub enum ConfigError {
         max: u64,
         reason: &'static str,
     },
+    /// A field fell below its allowed minimum (for bounds stricter than "> 0").
+    #[error("config: {field} must be >= {min} ({reason})")]
+    BelowMin {
+        field: &'static str,
+        min: u64,
+        reason: &'static str,
+    },
 }
 
 impl JobsConfig {
@@ -302,6 +309,10 @@ pub struct FxConfig {
     /// Deterministic provider fallback order (by `provider_id`); empty until an
     /// adapter is configured.
     pub provider_order: Vec<String>,
+    /// Vendor of the FX rate-provider plugin the `RateSyncJob` discovers each tick
+    /// from the types-registry (`RateProviderPluginSpecV1` instances). Must match
+    /// the external `bss-rate-provider` core gear's advertised `vendor`.
+    pub provider_vendor: String,
 }
 
 impl Default for FxConfig {
@@ -313,6 +324,7 @@ impl Default for FxConfig {
             rate_sync_tick_secs: 3_600,
             revaluation_run_tick_secs: 86_400,
             provider_order: Vec::new(),
+            provider_vendor: "cf.bss".to_owned(),
         }
     }
 }
@@ -323,6 +335,15 @@ impl Default for FxConfig {
 /// window overflows chrono's millisecond representation) — bound it at `validate`.
 const MAX_STALE_G10_HOURS: u64 = 168;
 
+/// Lower bound on `rate_sync_tick_secs`. The `FxNoFetchAttempted` alert reads a
+/// `3 × rate_sync_tick_secs` window of the adapter's completion metrics, and one
+/// source attempt can stay in flight for up to the adapter's 30 s per-source
+/// timeout ceiling — with a sub-minute tick a single slow attempt could span the
+/// whole alert window and read as "no attempt occurred". A 60 s floor keeps that
+/// window at ≥ 180 s, and nothing needs sub-minute FX syncs against feeds that
+/// publish daily.
+const MIN_RATE_SYNC_TICK_SECS: u64 = 60;
+
 impl FxConfig {
     /// Validate the FX tunables.
     ///
@@ -330,10 +351,11 @@ impl FxConfig {
     /// Returns `Err` if `stale_default_max_days > 7` (F3: a threshold above the
     /// 7-day bound must be rejected, never silently clamped), if `stale_g10_hours`
     /// exceeds [`MAX_STALE_G10_HOURS`] (a larger window overflows
-    /// `chrono::Duration::hours` and panics in `rate_source::is_stale`), or if any
-    /// of `stale_g10_hours` / `rate_sync_tick_secs` / `revaluation_run_tick_secs`
-    /// is `0` (a zero staleness window admits any rate; a zero tick panics
-    /// `tokio::time::interval`).
+    /// `chrono::Duration::hours` and panics in `rate_source::is_stale`), if
+    /// `rate_sync_tick_secs` is below [`MIN_RATE_SYNC_TICK_SECS`] (the
+    /// `FxNoFetchAttempted` alert-window bound — see the constant's docs), or if
+    /// `stale_g10_hours` / `revaluation_run_tick_secs` is `0` (a zero staleness
+    /// window admits any rate; a zero tick panics `tokio::time::interval`).
     pub fn validate(&self) -> Result<(), ConfigError> {
         if self.stale_default_max_days > 7 {
             return Err(ConfigError::AboveMax {
@@ -354,9 +376,11 @@ impl FxConfig {
                 reason: "7-day bound",
             });
         }
-        if self.rate_sync_tick_secs == 0 {
-            return Err(ConfigError::MustBePositive {
+        if self.rate_sync_tick_secs < MIN_RATE_SYNC_TICK_SECS {
+            return Err(ConfigError::BelowMin {
                 field: "fx.rate_sync_tick_secs",
+                min: MIN_RATE_SYNC_TICK_SECS,
+                reason: "FxNoFetchAttempted alert-window bound",
             });
         }
         if self.revaluation_run_tick_secs == 0 {

--- a/gears/bss/ledger/ledger/src/config_tests.rs
+++ b/gears/bss/ledger/ledger/src/config_tests.rs
@@ -152,6 +152,30 @@ fn over_seven_days_stale_default_rejected() {
     assert!(cfg.validate().is_err());
 }
 
+/// A sub-floor tick must be rejected: the `FxNoFetchAttempted` alert window is
+/// `3 ×` the tick, and one attempt can stay in flight for up to the adapter's
+/// 30 s per-source timeout ceiling — a sub-minute tick would let a single slow
+/// attempt span the whole window and read as "no attempt occurred".
+#[test]
+fn sub_floor_rate_sync_tick_rejected() {
+    let cfg = FxConfig {
+        rate_sync_tick_secs: MIN_RATE_SYNC_TICK_SECS - 1,
+        ..FxConfig::default()
+    };
+    assert!(cfg.validate().is_err());
+}
+
+/// The floor itself must validate — together with the rejection above this pins
+/// the bound exactly, where either test alone would pass for an arbitrary one.
+#[test]
+fn rate_sync_tick_at_the_floor_validates() {
+    let cfg = FxConfig {
+        rate_sync_tick_secs: MIN_RATE_SYNC_TICK_SECS,
+        ..FxConfig::default()
+    };
+    assert!(cfg.validate().is_ok());
+}
+
 #[test]
 fn default_recon_config_validates() {
     assert!(ReconConfig::default().validate().is_ok());

--- a/gears/bss/ledger/ledger/src/domain/ports/metrics.rs
+++ b/gears/bss/ledger/ledger/src/domain/ports/metrics.rs
@@ -303,6 +303,41 @@ pub trait LedgerMetricsPort: Send + Sync + 'static {
     /// the one monotonic counter). Both labels are bounded cardinality (the
     /// functional currency is per-tenant; direction is a two-value closed set).
     fn fx_realized_minor(&self, amount_minor: i64, functional_currency: &str, direction: &str);
+    /// Increment the FX rate-sync heartbeat: `ledger_fx_rate_sync_ticks_total` —
+    /// one `RateSyncJob` scheduler tick *started*.
+    ///
+    /// Counts ticks, not fetches, and is therefore the only signal that separates
+    /// two failure modes an error-based alert cannot tell apart:
+    ///
+    /// * counter flat → the ticker task is dead, so nothing is syncing at all. No
+    ///   fetch is attempted, so no fetch error is produced and the provider-failure
+    ///   alarm (`FX_SNAPSHOT_MISSING`) never fires — the rate store just ages until
+    ///   a post blocks on staleness.
+    /// * counter rising while the adapter's `fx_provider_fetch_duration_seconds`
+    ///   count stays flat → the job is alive but discovery yields no sources (a
+    ///   `vendor` typo, an unavailable types-registry, no source plugin registered).
+    ///
+    /// Unlabelled on purpose: the tick happens before any provider is resolved, so
+    /// there is no provider identity to attribute it to.
+    fn fx_rate_sync_ticked(&self);
+    /// Record one `RateSyncJob` pass latency sample in seconds:
+    /// `ledger_fx_rate_sync_duration_seconds` (histogram) — the wall time from the
+    /// start of a tick until the pass returned, provider discovery and every source
+    /// attempt included.
+    ///
+    /// The pass is what has to fit inside `fx.rate_sync_tick_secs`, and until this
+    /// existed nothing measured it. The adapter's
+    /// `fx_provider_fetch_duration_seconds` times one source's HTTP round-trip,
+    /// while the composite tries its sources **sequentially**, so a pass costs their
+    /// sum plus discovery — a quantity no per-source series reports.
+    ///
+    /// The heartbeat above catches an overrun only once it is severe enough to skip
+    /// whole tick windows. This is the direct measure: compare its p95 against the
+    /// configured interval and an overrun is visible before it starves a refresh.
+    ///
+    /// Recorded on every pass, including a failed one — a slow failure is exactly
+    /// the case worth seeing — and unlabelled, matching the heartbeat it pairs with.
+    fn fx_rate_sync_duration(&self, secs: f64);
 
     // ── Slice 7 Phase 3 reconciliation ─────────────────────────────────────────
     /// Record the signed variance (minor units) observed by one reconciliation
@@ -380,6 +415,8 @@ impl LedgerMetricsPort for NoopLedgerMetrics {
     fn fx_revaluation_duration(&self, _: f64) {}
     fn fx_provider_fallback(&self, _: &str) {}
     fn fx_realized_minor(&self, _: i64, _: &str, _: &str) {}
+    fn fx_rate_sync_ticked(&self) {}
+    fn fx_rate_sync_duration(&self, _: f64) {}
     fn reconciliation_variance_minor(&self, _: &str, _: i64) {}
     fn reconciliation_run(&self, _: &str) {}
     fn reconciliation_out_of_tolerance(&self, _: &str) {}
@@ -471,6 +508,8 @@ mod tests {
         m.fx_revaluation_duration(1.5);
         m.fx_provider_fallback("ecb");
         m.fx_realized_minor(240, "USD", "loss");
+        m.fx_rate_sync_ticked();
+        m.fx_rate_sync_duration(0.8);
     }
 
     // `NoopLedgerMetrics` is the trait's safe default — usable behind the

--- a/gears/bss/ledger/ledger/src/infra/fx/rate_source_tests.rs
+++ b/gears/bss/ledger/ledger/src/infra/fx/rate_source_tests.rs
@@ -14,6 +14,7 @@ fn cfg(g10_hours: u64, default_days: u64, order: &[&str]) -> FxConfig {
         rate_sync_tick_secs: 3_600,
         revaluation_run_tick_secs: 86_400,
         provider_order: order.iter().map(|s| (*s).to_owned()).collect(),
+        provider_vendor: "cf.bss".to_owned(),
     }
 }
 

--- a/gears/bss/ledger/ledger/src/infra/jobs/rate_sync.rs
+++ b/gears/bss/ledger/ledger/src/infra/jobs/rate_sync.rs
@@ -121,12 +121,18 @@ impl RateSyncJob {
                     // A CONFIGURED provider failed: the local store goes stale, so
                     // FX-needing posts will block at lock time. Alarm + log; never
                     // abort the gear.
+                    // `request_id` on both the log line and the alarm: it is the
+                    // only link from this one failed tick to the adapter's
+                    // per-source attempt lines, which carry the same id. The error
+                    // here is a composite's LAST source's, so on its own it names
+                    // neither the outage nor how many sources were tried.
                     tracing::error!(
                         provider = self.provider.provider_id(),
+                        request_id = %request_id,
                         error = %e,
                         "bss-ledger: FX rate-sync provider fetch failed; raising FX_SNAPSHOT_MISSING"
                     );
-                    self.emit_snapshot_missing(&ctx, self.provider.provider_id(), &e)
+                    self.emit_snapshot_missing(&ctx, self.provider.provider_id(), &request_id, &e)
                         .await;
                 }
                 return Ok(RateSyncReport::default());
@@ -146,7 +152,9 @@ impl RateSyncJob {
 
         // Fan the global rates out to every provisioned tenant's local store.
         let tenants = self.provisioned_tenants().await?;
-        let provider_id = self.provider.provider_id();
+        // The adapter's identity, for log attribution only — each stored row's
+        // `provider` comes from the rate that carries it (see `upsert_tenant`).
+        let adapter_id = self.provider.provider_id();
         let mut report = RateSyncReport {
             fetched: true,
             rates: u64::try_from(rates.len()).unwrap_or(u64::MAX),
@@ -154,11 +162,11 @@ impl RateSyncJob {
             failed_tenants: 0,
         };
         for tenant in tenants {
-            if let Err(e) = self.upsert_tenant(tenant, &rates, provider_id).await {
+            if let Err(e) = self.upsert_tenant(tenant, &rates, adapter_id).await {
                 report.failed_tenants += 1;
                 tracing::error!(
                     tenant_id = %tenant,
-                    provider = provider_id,
+                    adapter = adapter_id,
                     error = %e,
                     "bss-ledger: FX rate upsert failed for tenant; continuing"
                 );
@@ -189,13 +197,20 @@ impl RateSyncJob {
     }
 
     /// Upsert every fetched rate into one tenant's `ledger_fx_rate` store under
-    /// the provider id. A whole tenant is one isolation unit (the caller logs +
-    /// continues on `Err`).
+    /// the provider that published it. A whole tenant is one isolation unit (the
+    /// caller logs + continues on `Err`).
+    ///
+    /// The stored `provider` is taken from each rate's own
+    /// [`ProviderRate::provider`], not from the adapter's `provider_id()`: a
+    /// composite adapter serves one whole document from whichever source
+    /// answered first, so the publishing upstream varies between calls and only
+    /// the rate itself knows which one it was. `adapter_id` is the adapter's
+    /// constant identity and is used for log attribution only.
     async fn upsert_tenant(
         &self,
         tenant: Uuid,
         rates: &[ProviderRate],
-        provider_id: &str,
+        adapter_id: &str,
     ) -> anyhow::Result<()> {
         for rate in rates {
             // Never poison the local store with a non-positive quote: a rate
@@ -207,7 +222,8 @@ impl RateSyncJob {
                 tracing::warn!(
                     target: "bss-ledger.rate-sync",
                     tenant = %tenant,
-                    provider = provider_id,
+                    adapter = adapter_id,
+                    provider = %rate.provider,
                     base = %rate.base,
                     quote = %rate.quote,
                     rate_micro = rate.rate_micro,
@@ -220,14 +236,19 @@ impl RateSyncJob {
                     tenant_id: tenant,
                     base_currency: rate.base.clone(),
                     quote_currency: rate.quote.clone(),
-                    provider: provider_id.to_owned(),
+                    provider: rate.provider.clone(),
                     rate_micro: rate.rate_micro,
                     as_of: rate.as_of,
                     fallback_order: SYNC_FALLBACK_ORDER,
                 })
                 .await
                 .map_err(|e| {
-                    anyhow::anyhow!("upsert {}->{} ({provider_id}): {e}", rate.base, rate.quote)
+                    anyhow::anyhow!(
+                        "upsert {}->{} ({}, via adapter {adapter_id}): {e}",
+                        rate.base,
+                        rate.quote,
+                        rate.provider
+                    )
                 })?;
         }
         Ok(())
@@ -242,6 +263,7 @@ impl RateSyncJob {
         &self,
         ctx: &SecurityContext,
         provider_id: &str,
+        request_id: &str,
         err: &RateProviderError,
     ) {
         let category = AlarmCategory::FxSnapshotMissing;
@@ -251,14 +273,31 @@ impl RateSyncJob {
             tenant_id: Uuid::nil(),
             scope: "fx-rate-sync".to_owned(),
             code: category.as_str().to_owned(),
-            detail: format!(
-                "FX rate-sync provider '{provider_id}' fetch failed: {err}; \
-                 local rate store not refreshed"
-            ),
+            detail: snapshot_missing_detail(provider_id, request_id, err),
             affected: vec![],
         };
         self.publisher.emit_invariant_alarm(ctx, alarm).await;
     }
+}
+
+/// Build the `FX_SNAPSHOT_MISSING` alarm detail.
+///
+/// Split out from [`RateSyncJob::emit_snapshot_missing`] so the wording — the
+/// `request_id` in particular — is assertable without a recording publisher.
+///
+/// `request_id` is the load-bearing field. `provider_id` is the *composite
+/// adapter's* id rather than the source that broke, and `err` is only the LAST
+/// source's error, since a composite tries its sources in order and can return
+/// just one error value. The individual attempts survive as the adapter's `warn`
+/// lines, each stamped with this same `request_id`. Without it here, an operator
+/// holding the alarm has no key to filter those lines by and cannot tell which
+/// source actually failed, or whether the others failed too.
+fn snapshot_missing_detail(provider_id: &str, request_id: &str, err: &RateProviderError) -> String {
+    format!(
+        "FX rate-sync provider '{provider_id}' fetch failed: {err}; \
+         local rate store not refreshed; request_id={request_id} \
+         (filter the rate-provider adapter's logs by it for the per-source attempts)"
+    )
 }
 
 #[cfg(test)]

--- a/gears/bss/ledger/ledger/src/infra/jobs/rate_sync_tests.rs
+++ b/gears/bss/ledger/ledger/src/infra/jobs/rate_sync_tests.rs
@@ -52,20 +52,47 @@ impl RateProviderV1 for FakeProvider {
         _request_id: &str,
     ) -> Result<Vec<ProviderRate>, RateProviderError> {
         match &self.outcome {
-            Outcome::Ok(rates) => Ok(rates.clone()),
+            // Stamp this source's own id onto every rate, exactly as a real
+            // source does — the fixtures deliberately carry a different
+            // placeholder, so a rate reaching the store still labelled
+            // `unstamped` proves the provenance was never applied.
+            Outcome::Ok(rates) => Ok(rates
+                .iter()
+                .map(|r| ProviderRate {
+                    provider: self.id.clone(),
+                    ..r.clone()
+                })
+                .collect()),
             Outcome::Fail => Err(RateProviderError::Unreachable("fake outage".to_owned())),
         }
+    }
+
+    /// Always reachable. The sync job never calls this — it only fetches — so the
+    /// fake keeps it trivially `Ok` rather than modelling an outcome no assertion
+    /// here reads.
+    async fn health(
+        &self,
+        _ctx: &SecurityContext,
+        _request_id: &str,
+    ) -> Result<(), RateProviderError> {
+        Ok(())
     }
 }
 
 /// A `ProviderRate` literal (timestamp = now; staleness is the resolver's
 /// concern, not the sync job's).
+///
+/// `provider` is a placeholder the serving source overwrites with its own id,
+/// which is where the value the job stores actually comes from. Left distinct
+/// from any fake's id on purpose: an assertion on the stored provenance then
+/// fails loudly if the stamping step is ever dropped.
 fn rate(base: &str, quote: &str, rate_micro: i64) -> ProviderRate {
     ProviderRate {
         base: base.to_owned(),
         quote: quote.to_owned(),
         rate_micro,
         as_of: Utc::now(),
+        provider: "unstamped".to_owned(),
     }
 }
 
@@ -109,6 +136,28 @@ async fn configured_provider_failure_never_aborts() {
     let report = job.run().await.expect("a provider outage never aborts");
     assert!(!report.fetched);
     assert_eq!(report.rates, 0);
+}
+
+#[test]
+fn snapshot_missing_detail_carries_the_request_id_for_log_correlation() {
+    // The alarm's own fields cannot identify the outage: `provider_id` is the
+    // composite adapter's id, not the source that broke, and the error is only the
+    // LAST source a composite tried. The `request_id` is what makes the tick
+    // reconstructable — the adapter stamps the same id on a `warn` line per
+    // attempted source, so filtering by it yields the full sequence in priority
+    // order. Assert every part an operator reads, since dropping any one of them
+    // leaves the alarm unactionable.
+    let detail = snapshot_missing_detail(
+        "fx-composite",
+        "0199a3c4-1d2e-7f00-8000-000000000001",
+        &RateProviderError::Unreachable("connect timed out".to_owned()),
+    );
+    assert!(detail.contains("fx-composite"), "{detail}");
+    assert!(
+        detail.contains("request_id=0199a3c4-1d2e-7f00-8000-000000000001"),
+        "the alarm must carry the tick's request_id: {detail}"
+    );
+    assert!(detail.contains("connect timed out"), "{detail}");
 }
 
 #[tokio::test]

--- a/gears/bss/ledger/ledger/src/infra/metrics.rs
+++ b/gears/bss/ledger/ledger/src/infra/metrics.rs
@@ -94,6 +94,16 @@ const LEDGER_FX_PROVIDER_FALLBACK: &str = "ledger_fx_provider_fallback_total";
 // magnitude moved through `FX_GAIN_LOSS` on a cross-currency allocation close,
 // labelled by functional currency + gain/loss direction.
 const LEDGER_FX_REALIZED_MINOR: &str = "ledger_fx_realized_minor";
+// FX rate-sync scheduler heartbeat: one increment per `RateSyncJob` tick started.
+// Plural + past tense on purpose — `fx_rate_sync_tick` is already the name of the
+// *interval* (`FxConfig::rate_sync_tick_secs`), and the two sit two lines apart in
+// the ticker loop.
+const LEDGER_FX_RATE_SYNC_TICKS: &str = "ledger_fx_rate_sync_ticks_total";
+// Whole-pass duration of one `RateSyncJob` tick, discovery + every sequential
+// source attempt included. Distinct from the adapter's per-source
+// `fx_provider_fetch_duration_seconds`: the pass is what must fit inside the
+// configured interval, and only its own series can be compared against that.
+const LEDGER_FX_RATE_SYNC_DURATION: &str = "ledger_fx_rate_sync_duration_seconds";
 // ── Slice 7 Phase 3 reconciliation (design §9 / spec §3.5 J4) ─────────────────
 // The per-check signed-variance gauge, the run + out-of-tolerance counters (both
 // by check_type; out_of_tolerance/runs = the breach rate), the period-close-
@@ -182,6 +192,8 @@ pub struct LedgerMetricsMeter {
     fx_revaluation_duration: Histogram<f64>,
     fx_provider_fallback: Counter<u64>,
     fx_realized_minor: Counter<u64>,
+    fx_rate_sync_ticks: Counter<u64>,
+    fx_rate_sync_duration: Histogram<f64>,
     reconciliation_variance_minor: Gauge<i64>,
     reconciliation_runs: Counter<u64>,
     reconciliation_out_of_tolerance: Counter<u64>,
@@ -402,6 +414,21 @@ impl LedgerMetricsMeter {
                 .with_description(
                     "Realized FX magnitude (minor units) on a cross-currency close, by \
                      functional currency + gain/loss direction",
+                )
+                .build(),
+            fx_rate_sync_ticks: meter
+                .u64_counter(LEDGER_FX_RATE_SYNC_TICKS)
+                .with_description(
+                    "FX rate-sync scheduler ticks started (job-liveness heartbeat; a flat \
+                     counter means the ticker is dead, not that the feed is)",
+                )
+                .build(),
+            fx_rate_sync_duration: meter
+                .f64_histogram(LEDGER_FX_RATE_SYNC_DURATION)
+                .with_description(
+                    "FX rate-sync pass wall time in seconds, discovery and every sequential \
+                     source attempt included (compare against fx.rate_sync_tick_secs: a pass \
+                     that outgrows its own interval starves refreshes)",
                 )
                 .build(),
             reconciliation_variance_minor: meter
@@ -675,6 +702,13 @@ impl LedgerMetricsPort for LedgerMetricsMeter {
                 KeyValue::new("direction", direction.to_owned()),
             ],
         );
+    }
+    fn fx_rate_sync_ticked(&self) {
+        self.fx_rate_sync_ticks.add(1, &[]);
+    }
+
+    fn fx_rate_sync_duration(&self, secs: f64) {
+        self.fx_rate_sync_duration.record(secs, &[]);
     }
 
     fn reconciliation_variance_minor(&self, check_type: &str, variance_minor: i64) {

--- a/gears/bss/ledger/ledger/src/infra/metrics_tests.rs
+++ b/gears/bss/ledger/ledger/src/infra/metrics_tests.rs
@@ -317,3 +317,37 @@ fn reconciliation_slice7_metrics_are_observable() {
         4
     );
 }
+
+#[test]
+fn fx_rate_sync_heartbeat_is_observable_and_unlabelled() {
+    let h = MetricsHarness::new();
+    let m = h.metrics();
+    // The job-liveness heartbeat: one increment per scheduler tick started. It is
+    // the only signal that catches a stalled ticker — no fetch is attempted, so no
+    // fetch error is produced and FX_SNAPSHOT_MISSING never fires. An alert reads
+    // it as "no increase over 3 x fx.rate_sync_tick_secs", which only works if the
+    // series exists and carries no attributes to split it.
+    m.fx_rate_sync_ticked();
+    m.fx_rate_sync_ticked();
+    m.fx_rate_sync_ticked();
+    h.force_flush();
+    assert_eq!(h.counter_value("ledger_fx_rate_sync_ticks_total", &[]), 3);
+}
+
+#[test]
+fn fx_rate_sync_duration_is_observable_and_unlabelled() {
+    let h = MetricsHarness::new();
+    let m = h.metrics();
+    // The whole-pass latency: the only series that can be compared against
+    // `fx.rate_sync_tick_secs`, since the adapter's per-source histogram times one
+    // HTTP round-trip while the composite tries its sources one after another.
+    // Unlabelled for the same reason as the heartbeat it pairs with — the pass
+    // spans discovery, so it belongs to no single provider.
+    m.fx_rate_sync_duration(0.4);
+    m.fx_rate_sync_duration(2.5);
+    h.force_flush();
+    assert_eq!(
+        h.histogram_count("ledger_fx_rate_sync_duration_seconds", &[]),
+        2
+    );
+}

--- a/gears/bss/ledger/ledger/src/module.rs
+++ b/gears/bss/ledger/ledger/src/module.rs
@@ -140,11 +140,15 @@ pub(crate) struct LedgerRuntime {
     pub recognition_run_tick: Duration,
     /// Chain-verifier tick cadence.
     pub verify_tick: Duration,
-    /// FX rate-provider plugin (Slice 5) resolved from `ClientHub` — the
-    /// fail-safe `UnconfiguredRateProviderV1` default when no adapter-gear is
-    /// registered. The `RateSyncJob` pulls `fetch_latest` from it each
-    /// `fx_rate_sync_tick` into the local rate store.
-    pub rate_provider: Arc<dyn RateProviderV1>,
+    /// Process `ClientHub` handle used to LAZILY discover the FX rate-provider
+    /// plugin each rate-sync tick (the composite the external `bss-rate-provider`
+    /// core gear registers as a `RateProviderPluginSpecV1` instance). Resolving
+    /// per tick — rather than once at init — means a late-registered adapter is
+    /// picked up on the next tick and there is no init-ordering dependency; absent
+    /// an adapter the resolver yields the fail-safe `UnconfiguredRateProviderV1`.
+    pub rate_provider_hub: Arc<toolkit::client_hub::ClientHub>,
+    /// Vendor selecting which rate-provider plugin instance the ticker resolves.
+    pub rate_provider_vendor: String,
     /// FX rate store (the `RateSyncJob` upsert target / the lock-time
     /// `RateSource` read target).
     pub fx_repo: crate::infra::storage::repo::FxRepo,
@@ -169,6 +173,11 @@ pub(crate) struct LedgerRuntime {
 // broker-free no-op/metrics-only publisher). Declaring it would make the gear
 // unschedulable (the orchestrator can't satisfy a dep no gear provides). Re-add
 // it here once the broker gear exists and `events_enabled` is wired to it.
+//
+// NOTE: the FX rate-provider adapter is NOT a `deps` edge — the `RateSyncJob`
+// discovers it lazily from the types-registry each tick (see `resolve_rate_provider`),
+// so a late-registered adapter self-heals and the ledger stays decoupled from
+// (and schedulable without) the external `bss-rate-provider` gear.
 #[toolkit::gear(name = "bss-ledger", capabilities = [db, rest, stateful], deps = [types_registry, authz_resolver, account_management], lifecycle(entry = "serve", stop_timeout = "30s"))]
 pub struct BssLedgerGear {
     /// Typed runtime built inside [`Gear::init`] and consumed by
@@ -182,6 +191,88 @@ impl Default for BssLedgerGear {
     fn default() -> Self {
         Self {
             runtime: ArcSwapOption::from(None),
+        }
+    }
+}
+
+/// Discover the FX rate-provider plugin from the types-registry (the composite
+/// the external `bss-rate-provider` core gear registers), selecting the instance
+/// by `vendor` + `priority`. Called fresh each rate-sync tick, so a
+/// late-registered adapter is picked up on the next tick — no init-ordering
+/// dependency. Falls back to the fail-safe
+/// [`UnconfiguredRateProviderV1`](bss_ledger_sdk::UnconfiguredRateProviderV1)
+/// whenever the registry is unavailable or no plugin is registered, so a missing
+/// adapter is a benign deployment state (the sync job logs at debug, no alarm),
+/// never a books defect.
+async fn resolve_rate_provider(
+    hub: &toolkit::client_hub::ClientHub,
+    vendor: &str,
+) -> Arc<dyn RateProviderV1> {
+    let fallback = || Arc::new(UnconfiguredRateProviderV1) as Arc<dyn RateProviderV1>;
+    // Every branch below logs before falling back. Silently returning the
+    // fail-safe made a types-registry outage or a malformed plugin instance
+    // indistinguishable from the benign "no adapter configured" state, so FX
+    // rates would go stale with nothing to diagnose from. Levels split by
+    // meaning: `warn` for something broken, `debug` for the expected
+    // not-configured case (the sync job already reports that one).
+    let registry = match hub.get::<dyn types_registry_sdk::TypesRegistryClient>() {
+        Ok(registry) => registry,
+        Err(e) => {
+            tracing::warn!(
+                vendor,
+                error = %e,
+                "bss-ledger: types-registry client unavailable; using the fail-safe FX \
+                 rate provider (rates will go stale)"
+            );
+            return fallback();
+        }
+    };
+    let type_id = bss_ledger_sdk::RateProviderPluginSpecV1::gts_type_id();
+    let instances = match registry
+        .list_instances(
+            types_registry_sdk::InstanceQuery::new().with_pattern(format!("{type_id}*")),
+        )
+        .await
+    {
+        Ok(instances) => instances,
+        Err(e) => {
+            tracing::warn!(
+                vendor,
+                error = %e,
+                "bss-ledger: listing FX rate-provider plugin instances failed; using the \
+                 fail-safe FX rate provider (rates will go stale)"
+            );
+            return fallback();
+        }
+    };
+    match toolkit::plugins::choose_plugin_instance::<bss_ledger_sdk::RateProviderPluginSpecV1>(
+        vendor,
+        instances.iter().map(|e| (e.id.as_ref(), &e.object)),
+    ) {
+        Ok(gts_id) => hub
+            .try_get_scoped::<dyn RateProviderV1>(&toolkit::client_hub::ClientScope::gts_id(
+                &gts_id,
+            ))
+            .unwrap_or_else(|| {
+                // Partial registration: the plugin published its instance but
+                // never registered (or failed before registering) its scoped
+                // client. Not the benign unconfigured state — warn.
+                tracing::warn!(
+                    vendor,
+                    instance_id = %gts_id,
+                    "bss-ledger: FX rate-provider plugin instance has no scoped client \
+                     registered; using the fail-safe FX rate provider"
+                );
+                fallback()
+            }),
+        Err(e) => {
+            tracing::debug!(
+                vendor,
+                error = %e,
+                "bss-ledger: no FX rate-provider plugin instance matched; using the \
+                 fail-safe default"
+            );
+            fallback()
         }
     }
 }
@@ -247,15 +338,41 @@ impl BssLedgerGear {
                     biased;
                     () = token.cancelled() => break,
                     _ = iv.tick() => {
+                        // Heartbeat FIRST, before discovery: this must count the tick
+                        // itself. A stalled ticker attempts no fetch, so it produces no
+                        // fetch error and never raises FX_SNAPSHOT_MISSING — the rate
+                        // store just ages until a post blocks on staleness. Incrementing
+                        // after resolve/fetch would go flat on a discovery failure too,
+                        // making a dead ticker indistinguishable from an empty registry.
+                        rt.metrics.fx_rate_sync_ticked();
+                        // Timed from here, alongside the heartbeat, so the sample covers
+                        // the whole pass — discovery included. The composite tries its
+                        // sources sequentially, so the pass, not any single source's
+                        // fetch, is what has to fit inside `fx_rate_sync_tick`; nothing
+                        // else measures it. The loop awaits the pass inline, so a pass
+                        // that outgrows the interval cannot overlap the next one — it
+                        // delays it, and this histogram is where that shows up first.
+                        let started = std::time::Instant::now();
+                        // Discover the rate-provider plugin fresh each tick (lazy,
+                        // self-healing) — the fail-safe default when none is registered.
+                        let provider = resolve_rate_provider(
+                            &rt.rate_provider_hub,
+                            &rt.rate_provider_vendor,
+                        )
+                        .await;
                         let job = crate::infra::jobs::rate_sync::RateSyncJob::new(
                             rt.db.clone(),
-                            Arc::clone(&rt.rate_provider),
+                            provider,
                             rt.fx_repo.clone(),
                             Arc::clone(&rt.publisher),
                         );
                         if let Err(e) = job.run().await {
                             tracing::error!(error = %e, "bss-ledger: rate-sync job tick failed");
                         }
+                        // Recorded on the failure path too: a pass that fails slowly is
+                        // exactly the one worth seeing, and dropping those samples would
+                        // bias the p95 the alert reads.
+                        rt.metrics.fx_rate_sync_duration(started.elapsed().as_secs_f64());
                     }
                 }
             }
@@ -946,18 +1063,17 @@ impl Gear for BssLedgerGear {
         let rt_enforcer = Arc::clone(&enforcer);
         let rt_metrics = Arc::clone(&metrics);
 
-        // FX rate-provider plugin (Slice 5): resolved from `ClientHub` like the
-        // other cross-gear clients, but with a fail-safe DEFAULT — the external
-        // ECB/bank adapter-gear is out of Slice 5 scope, so absent the adapter the
-        // gear falls back to `UnconfiguredRateProviderV1` (every fetch errors → the
-        // local rate store stays empty → FX-needing posts block at lock time,
-        // never a silent wrong rate). Unlike authz, a missing rate adapter is NOT
-        // fatal to init. The `RateSyncJob` (serve loop) pulls into `fx_repo`, whose
-        // db clone is captured here before `db` moves into the client below.
-        let rate_provider: Arc<dyn RateProviderV1> = ctx
-            .client_hub()
-            .get::<dyn RateProviderV1>()
-            .unwrap_or_else(|_| Arc::new(UnconfiguredRateProviderV1));
+        // FX rate-provider plugin (Slice 5): discovered LAZILY from the
+        // types-registry each rate-sync tick (see `resolve_rate_provider`), not
+        // resolved once here — so a late-registered adapter is picked up next tick
+        // and the ledger needs no `deps` edge on it. Absent an adapter the resolver
+        // yields the fail-safe `UnconfiguredRateProviderV1` (every fetch errors →
+        // the local store stays empty → FX-needing posts block at lock time, never
+        // a silent wrong rate); a missing adapter is NOT fatal to init. The hub
+        // handle + selection vendor are captured for the serve-loop ticker. The
+        // `fx_repo` db clone is captured before `db` moves into the client below.
+        let rate_provider_hub = ctx.client_hub();
+        let rate_provider_vendor = cfg.fx.provider_vendor.clone();
         let fx_repo = crate::infra::storage::repo::FxRepo::new(db.clone());
 
         // Slice 7 Phase 3: the three launch-blocking control feeds (issued-invoice
@@ -1420,7 +1536,8 @@ impl Gear for BssLedgerGear {
             aged_alarm_tick: cfg.jobs.aged_alarm_interval(),
             recognition_run_tick: cfg.recognition.recognition_run_interval(),
             verify_tick: cfg.jobs.verify_interval(),
-            rate_provider,
+            rate_provider_hub,
+            rate_provider_vendor,
             fx_repo,
             fx_rate_sync_tick: cfg.fx.rate_sync_interval(),
             fx_config: cfg.fx.clone(),
@@ -1560,3 +1677,7 @@ impl RestApiCapability for BssLedgerGear {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "module_tests.rs"]
+mod tests;

--- a/gears/bss/ledger/ledger/src/module_tests.rs
+++ b/gears/bss/ledger/ledger/src/module_tests.rs
@@ -1,0 +1,121 @@
+//! Tests for the lazy FX rate-provider plugin discovery
+//! ([`resolve_rate_provider`](super::resolve_rate_provider)): it resolves the
+//! composite plugin the external gear registers, and falls back to the fail-safe
+//! `UnconfiguredRateProviderV1` (`provider_id() == "none"`, so the sync job stays
+//! silent, no alarm) whenever the registry is unavailable or no matching plugin
+//! is registered.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use bss_ledger_sdk::{
+    CurrencyPair, ProviderRate, RateProviderError, RateProviderPluginSpecV1, RateProviderV1,
+};
+use toolkit::client_hub::{ClientHub, ClientScope};
+use toolkit::gts::PluginV1;
+use toolkit_security::SecurityContext;
+use types_registry_sdk::TypesRegistryClient;
+use types_registry_sdk::testing::{MockTypesRegistryClient, make_test_instance};
+
+use super::resolve_rate_provider;
+
+/// A stand-in composite whose `provider_id` is a real (non-`"none"`) id.
+struct FakeComposite;
+
+#[async_trait]
+impl RateProviderV1 for FakeComposite {
+    #[allow(
+        clippy::unnecessary_literal_bound,
+        reason = "trait signature is `-> &str` tied to &self; this fake returns a literal"
+    )]
+    fn provider_id(&self) -> &str {
+        "ecb"
+    }
+    async fn fetch_latest(
+        &self,
+        _ctx: &SecurityContext,
+        _pairs: &[CurrencyPair],
+        _request_id: &str,
+    ) -> Result<Vec<ProviderRate>, RateProviderError> {
+        Ok(vec![])
+    }
+
+    /// These tests exercise provider *resolution*, not probing, so reachability is
+    /// a trivial `Ok`.
+    async fn health(
+        &self,
+        _ctx: &SecurityContext,
+        _request_id: &str,
+    ) -> Result<(), RateProviderError> {
+        Ok(())
+    }
+}
+
+/// A hub advertising one composite rate-provider plugin (under `vendor`).
+///
+/// When `register_scoped_client` is false the `PluginV1` instance is published
+/// but no scoped client is bound to it — the partial-registration state a plugin
+/// is briefly in, or gets stuck in when its `init()` fails after registering the
+/// instance but before registering the client.
+fn hub_with_composite(vendor: &str, register_scoped_client: bool) -> Arc<ClientHub> {
+    let hub = Arc::new(ClientHub::default());
+    let (id, json) = PluginV1::<RateProviderPluginSpecV1>::build_registration(
+        "cf.bss.rate_provider_composite.plugin.v1",
+        vendor,
+        100,
+    )
+    .unwrap();
+    let id_str = id.as_ref().to_owned();
+    let registry: Arc<dyn TypesRegistryClient> = Arc::new(
+        MockTypesRegistryClient::new().with_instances([make_test_instance(&id_str, json)]),
+    );
+    hub.register::<dyn TypesRegistryClient>(registry);
+    if register_scoped_client {
+        let composite: Arc<dyn RateProviderV1> = Arc::new(FakeComposite);
+        hub.register_scoped::<dyn RateProviderV1>(ClientScope::gts_id(&id_str), composite);
+    }
+    hub
+}
+
+#[tokio::test]
+async fn resolves_registered_composite() {
+    let hub = hub_with_composite("cf.bss", true);
+    let provider = resolve_rate_provider(&hub, "cf.bss").await;
+    assert_eq!(provider.provider_id(), "ecb");
+}
+
+#[tokio::test]
+async fn falls_back_to_unconfigured_when_no_registry() {
+    // No `TypesRegistryClient` registered at all.
+    let hub = ClientHub::default();
+    let provider = resolve_rate_provider(&hub, "cf.bss").await;
+    assert_eq!(provider.provider_id(), "none");
+}
+
+#[tokio::test]
+async fn falls_back_to_unconfigured_on_vendor_mismatch() {
+    let hub = hub_with_composite("cf.bss", true);
+    let provider = resolve_rate_provider(&hub, "some-other-vendor").await;
+    assert_eq!(provider.provider_id(), "none");
+}
+
+#[tokio::test]
+async fn falls_back_to_unconfigured_when_no_instances() {
+    let hub = Arc::new(ClientHub::default());
+    let registry: Arc<dyn TypesRegistryClient> = Arc::new(MockTypesRegistryClient::new());
+    hub.register::<dyn TypesRegistryClient>(registry);
+    let provider = resolve_rate_provider(&hub, "cf.bss").await;
+    assert_eq!(provider.provider_id(), "none");
+}
+
+#[tokio::test]
+async fn falls_back_to_unconfigured_when_the_chosen_instance_has_no_scoped_client() {
+    // Realistic partial registration: the plugin published its `PluginV1`
+    // instance, so vendor selection succeeds, but no scoped `RateProviderV1` is
+    // bound to that id. The resolver must take the fail-safe path (and log a
+    // warning — this is a broken deployment, not the benign unconfigured state)
+    // rather than panicking or handing back something unusable.
+    let hub = hub_with_composite("cf.bss", false);
+    let provider = resolve_rate_provider(&hub, "cf.bss").await;
+    assert_eq!(provider.provider_id(), "none");
+}

--- a/gears/bss/rate-provider/docs/DESIGN.md
+++ b/gears/bss/rate-provider/docs/DESIGN.md
@@ -1,0 +1,1331 @@
+<!-- CONFLUENCE_TITLE: [BSS]: FX Rate Provider (Adapter Gear) — Technical Design -->
+<!-- Related: ../../ledger/docs/DESIGN.md, ../../ledger/docs/design/06-fx-multicurrency.md, ../../ledger/docs/PRD.md | Owners: @vstudzinskyi (BSS Billing Platform team) -->
+
+# Technical Design — FX Rate Provider (Adapter Gear)
+
+<!-- toc -->
+
+- [1. Architecture Overview](#1-architecture-overview)
+  - [1.1 Architectural Vision](#11-architectural-vision)
+  - [1.2 Architecture Drivers](#12-architecture-drivers)
+  - [1.3 Architecture Layers](#13-architecture-layers)
+- [2. Principles & Constraints](#2-principles--constraints)
+  - [2.1 Design Principles](#21-design-principles)
+  - [2.2 Constraints](#22-constraints)
+- [3. Technical Architecture](#3-technical-architecture)
+  - [3.1 Domain Model](#31-domain-model)
+  - [3.2 Component Model](#32-component-model)
+  - [3.3 API Contracts](#33-api-contracts)
+  - [3.4 Internal Dependencies](#34-internal-dependencies)
+  - [3.5 External Dependencies](#35-external-dependencies)
+  - [3.6 Interactions & Sequences](#36-interactions--sequences)
+  - [3.7 Database schemas & tables](#37-database-schemas--tables)
+  - [3.8 Deployment Topology](#38-deployment-topology)
+- [4. Additional context](#4-additional-context)
+  - [Security & AuthZ](#security--authz)
+  - [Feature metrics](#feature-metrics)
+  - [Testing architecture](#testing-architecture)
+  - [Decision register](#decision-register)
+  - [Companion ledger change (hard dependency, from O-3)](#companion-ledger-change-hard-dependency-from-o-3)
+- [5. Traceability](#5-traceability)
+
+<!-- /toc -->
+
+- [ ] `p1` - **ID**: `cpt-cf-bss-rate-provider-design-main`
+
+> **Canonical design entry point.** This document is the FX rate-provider gear's technical
+> design and the anchor for spec traceability. The gear is small enough that the design is
+> **self-contained** — there is no slice set; component, contract, and sequence detail is
+> normative here.
+>
+> **Status**: DRAFT — decisions recorded (O-1 & O-3 decided; all other defaults accepted
+> 2026-07-08). Ready for implementation planning. The O-3 companion `bss-ledger` change
+> (§4 "Companion ledger change") is a linked hard dependency.
+>
+> **Implementation revision (2026-07-23) — `*-plugin` pattern.** The gear was
+> built on the platform's plugin pattern (types-registry `PluginV1` instances +
+> `ClientHub` scoped registration + host-side discovery), which revises three
+> decisions below. This note is authoritative where it conflicts with the older
+> prose:
+>
+> - **Two crates → four.** Instead of one composite gear with a config `sources[]`
+>   list, each source is its own **plugin gear** — `bss-rate-provider-ecb-plugin`
+>   and `bss-rate-provider-http-json-plugin` — and a **core gear**
+>   (`bss-rate-provider`) discovers and composes them. Shared source utilities
+>   (conversion, error mapping, fetch metrics) and the source-plugin GTS spec live
+>   in `bss-rate-provider-sdk`.
+> - **O-1 revised — scoped plugin registration, two layers.** *Level 1:* each
+>   source plugin registers a `PluginV1<RateProviderSourcePluginSpecV1>` instance
+>   in the types-registry and a scoped `RateProviderV1` client (`priority` = the
+>   fallback order). The core gear lists those instances, orders by `priority`,
+>   resolves each via `get_scoped`, and composes them (first whole successful
+>   document; provenance stamped per rate — see §3.2). *Level 2:* the core gear
+>   registers its composite as a `PluginV1<RateProviderPluginSpecV1>` (spec in
+>   `bss-ledger-sdk`) + scoped `RateProviderV1`; the ledger discovers **that**.
+> - **O-7 revised — no `deps` edge.** The ledger discovers the composite **lazily
+>   on every `RateSyncJob` tick** (types-registry `list_instances` → vendor/priority
+>   select → `get_scoped`), falling back to `UnconfiguredRateProviderV1`. A
+>   late-registered adapter self-heals on the next tick, so the startup-ordering
+>   concern is gone and the ledger stays decoupled (schedulable without the adapter).
+> - **O-12 revised — per-plugin config, not `sources[]`.** Source assembly is now
+>   plugin discovery ordered by each plugin's `priority`; the `fx.provider_order` /
+>   `sources[]` cross-gear order check is replaced by matching `vendor` between the
+>   core gear, its source plugins, and the ledger's `fx.provider_vendor`. Unknown
+>   `kind` no longer exists (each source is a distinct plugin crate). Config
+>   validation is per plugin (http-json requires `mapping` + https `base_url`).
+>
+> The domain model (§3.1), the fetch-only/direct-pairs/deterministic-conversion
+> principles (§2.1), the metrics (§4), and the O-3 triangulation boundary are
+> unchanged.
+
+## 1. Architecture Overview
+
+### 1.1 Architectural Vision
+
+The **FX rate-provider gear** is a **stateless adapter**: it implements the ledger's
+`RateProviderV1` contract (`bss-ledger-sdk`, GTS `gts.cf.bss.ledger.rate-provider.v1`) and
+registers an `Arc<dyn RateProviderV1>` into the platform `ClientHub`, so the ledger's
+background `RateSyncJob` resolves a live adapter instead of the fail-safe
+`UnconfiguredRateProviderV1` default. The registered instance is a
+**`DiscoveringRateProvider`** that lazily discovers source plugins and builds a
+**`CompositeRateProvider`** to try its ordered sources in the PRD-ratified provider
+order (2026-06-10) and returns the **first whole document** that succeeds (one source per
+document, never a merge; O-1 — a rule about provenance, not about coverage, see §2.1). The
+fallback **mechanism** ships in v1, but the **v1
+configuration is ECB-only** (O-10): the bank / PSP feed is a *future* source, added later
+by deploying/configuring one more source-plugin gear (its own crate, its own `vendor` +
+`priority`) — no change to this gear's code. It performs no persistence, no HTTP surface,
+and no accounting logic.
+
+**This gear only fetches rates.** The ledger declares the FX rate provider out of its own
+scope ("The FX rate provider itself (integration, feeds) — external; the ledger consumes
+rates and snapshots them",
+[`../../ledger/docs/design/06-fx-multicurrency.md`](../../ledger/docs/design/06-fx-multicurrency.md))
+and already ships the consuming seam: the `RateProviderV1` SDK trait, the `RateSyncJob`
+that pulls it, the `ledger_fx_rate` local store, the lock-time `RateSource`, staleness /
+provider-precedence resolution, and the immutable `rate_snapshot`. Everything ledger-owned
+stays there and is NOT restated here:
+
+- Functional-currency **translation** and the dual-column balance.
+- **Triangulation** through EUR (X→EUR→Y) — ledger-owned (O-3); requires the companion
+  ledger change (§4 "Companion ledger change").
+- **Staleness** rules (G10 > 24 h; others ≤ 7 d) and `stale` marking.
+- **Provider precedence / fallback-order** resolution over the local store.
+- **`rate_snapshot`** freezing, `ledger_fx_rate` upsert, per-tenant fan-out.
+- Realized / unrealized FX, revaluation runs.
+- The `RateSyncJob` tick cadence and its `FX_SNAPSHOT_MISSING` alarm (ledger-side).
+
+Also out of scope: **pricing-side FX / rate-lock governance** (Catalog module) and
+**provider commercial contracts / credential procurement** (ops).
+
+### 1.2 Architecture Drivers
+
+Requirements from the ledger [`PRD.md`](../../ledger/docs/PRD.md) and the FX slice design
+that significantly shape this gear.
+
+#### Functional Drivers
+
+| Requirement | Design Response |
+|-------------|-----------------|
+| `cpt-cf-bss-ledger-fr-multi-currency-fx` | The ledger needs a live rate feed to translate transaction currency into functional currency; this gear supplies it through the fixed `RateProviderV1` seam — implement `provider_id()`, `fetch_latest()`, `health()` (§3.3). |
+| `cpt-cf-bss-ledger-fr-fx-rate-source-failure` | Provider outage must never produce a silent wrong rate. The composite returns the last `RateProviderError` when **all** sources fail; the ledger job then alarms and FX posts block (`FX_RATE_UNAVAILABLE`) — fail-safe by absence (§2.2). |
+| Rate-source fallback ([ledger FX design](../../ledger/docs/design/06-fx-multicurrency.md)) | The ledger resolves precedence over its **local store**; cross-source fallback at fetch time is this gear's `CompositeRateProvider` — ordered sources, first whole successful document, true-source provenance (§3.2). |
+| Provider onboarding without code change | Plugin-discovery source assembly: the core gear discovers registered source-plugin instances by `vendor`, ordered by `priority`; a plain REST feed is onboarded by configuring `bss-rate-provider-http-json-plugin` alone (no code), a new provider *family* costs one new plugin crate (§3.2). |
+
+#### NFR Allocation
+
+| NFR theme | Allocated to | Design Response |
+|-----------|--------------|-----------------|
+| Post-path isolation (hard) | Consumption model | `fetch_latest` is called only by the background `RateSyncJob`, never on the posting path; a provider outage fails the job (ledger alarms), never a post. |
+| Feed freshness | Fetch path + ledger tick | A successful fetch SHOULD complete within one `rate_sync_tick` (ledger default 1 h) so G10 pairs never cross the 24 h staleness window under normal operation. |
+| Fetch latency | Sources + HTTP client | `fx_provider_fetch_duration_seconds{provider}` p95 ≤ 2 s **per source** (draft; confirm against ECB response times). One bounded attempt per source per call, no unbounded retry. The composite's worst case is the **sum of the configured per-source `timeout_ms`** (every source down). No shared total deadline is imposed in v1 — see the budget rule below for why that is safe and where it stops being safe. |
+| Availability | Ledger fail-safe | Best-effort; the ledger's fail-safe (block, not guess) absorbs adapter downtime. |
+
+**Fetch-budget rule.** Both the number of sources and each `timeout_ms` are
+configuration-driven, so the worst-case tick duration is not bounded by anything in the
+code. The rule that keeps it safe is a budget, not a deadline:
+
+> **sum of all configured `timeout_ms` MUST stay below one `rate_sync_tick`**, with an
+> order of magnitude to spare.
+
+At the defaults that is comfortable — 5 s per source against a 3600 s tick, so ~720 sources
+would be needed to reach the interval. It stops being comfortable in exactly two setups: a
+tick shortened to seconds, or per-source timeouts raised into the minutes. Both are
+deliberate operator choices, and both are worth checking against this rule before rollout.
+
+The **per-source half** of that budget is enforced in code: `build_source_http_client`
+rejects any `timeout_ms` above `MAX_TIMEOUT_MS` (30 s) at the plugin's `init()`, so a single
+misconfigured source cannot consume a tick on its own. The sum itself is deliberately not
+checked, because no single `init()` can see both halves of the rule — the timeouts live in
+each source plugin's config while the interval lives in the ledger's. The ceiling therefore
+catches the failure that actually occurs (a unit mix-up: seconds written into a milliseconds
+field) and leaves the genuinely cross-gear part of the rule to this document.
+
+No shared deadline is enforced in v1 because it would buy nothing on the failure path this
+gear actually has: the fetch runs only inside the background `RateSyncJob`, never on the
+posting path, so a slow tick delays a rate refresh but blocks no post. Overrunning the
+interval is the ledger scheduler's concern — it does not start a second concurrent tick,
+so an overrun manifests as a *skipped* refresh, not overlapping fetches.
+
+An overrun is measured where it happens, on the ledger side: it times the whole pass into
+`ledger_fx_rate_sync_duration_seconds` and alerts that p95 against the configured interval
+(`FxRateSyncOverrunning`). Nothing in this gear can substitute for that series — the
+per-source `fx_provider_fetch_duration_seconds` times one HTTP round-trip, while the pass
+costs the sum of every source tried plus discovery. What this gear's own
+`FxNoFetchAttempted` covers is the different, more severe state where
+`fx_provider_fetch_duration_seconds_count` stops advancing entirely (§4 "Feature metrics"),
+which against the ledger's still-rising tick heartbeat reads as skipped refreshes rather
+than a dead job.
+
+If a deployment ever needs the harder guarantee, the place to add it is a composite-level
+deadline in `CompositeRateProvider::fetch_latest` that stops trying further sources once
+the budget is spent — deliberately not v1 scope.
+
+#### Key Decisions
+
+The load-bearing decisions are recorded in the decision register (§4 "Decision register");
+the two that shape the architecture:
+
+| Decision | Summary |
+|----------|---------|
+| **O-1 — Composite adapter, no merge** | The ledger resolves exactly one `RateProviderV1` (a scoped `ClientHub` lookup as implemented — see §1.3), so per-provider registrations do not work today. This gear registers ONE composite (`DiscoveringRateProvider` building a `CompositeRateProvider`) that returns the first whole successful document — a snapshot period stays single-source-coherent for audit. Source provenance rides on each `ProviderRate` (§3.1), so the ledger stamps the true upstream per row rather than one id per pass (§3.2). |
+| **O-3 — Ledger owns triangulation** | The adapter emits **only the source's native direct pairs** (ECB's EUR pairs) — no cross-rate synthesis here. Cross-base rates (X→EUR→Y) are computed ledger-side in `RateSource`; enabling the ledger's deferred triangulation is a hard companion dependency (§4). |
+
+### 1.3 Architecture Layers
+
+Four crates, not one — each source plugin self-registers; the core gear discovers and
+composes them:
+
+```text
+Source-plugin gears   Each source is its OWN gear crate. Its init() builds the shared HTTP
+(bss-rate-provider-    client, registers a PluginV1<RateProviderSourcePluginSpecV1>
+  ecb-plugin,          instance in types-registry (vendor + priority in the instance JSON),
+  -http-json-plugin)   and register_scoped::<dyn RateProviderV1>(gts_id) in ClientHub.
+       │
+       ▼
+Core gear init()      Registers ITSELF as a PluginV1<RateProviderPluginSpecV1> instance +
+(bss-rate-provider)    scoped RateProviderV1 (the one the ledger discovers). Does NOT
+                       discover sources yet — that is deferred (see below).
+       │
+       ▼
+DiscoveringRateProvider   The registered instance. On EVERY fetch_latest/health call: lists
+(re-discovers every       types-registry instances of RateProviderSourcePluginSpecV1,
+ tick, self-healing)      keeps the ones whose vendor == source_vendor, sorts by priority,
+                          resolves each via get_scoped, and builds a fresh
+                          CompositeRateProvider — never cached across ticks, so a source
+                          plugin's registration, removal, or priority change takes effect
+                          on the very next tick, no restart needed. A failed discovery
+                          (zero matches) errors the tick — no composite is retained, and
+                          no source identity is carried over (provenance is per-rate).
+       │
+       ▼
+CompositeRateProvider   impl RateProviderV1 · ordered sources · first whole successful
+(selection)             document, returned unchanged — source-agnostic, stateless
+       │
+       ▼
+Sources            EcbRateProvider (bss-rate-provider-ecb-plugin: XML fetch/parse) ·
+(one per plugin)   HttpJsonRateProvider (bss-rate-provider-http-json-plugin: generic
+                   GET-JSON + field mapping)
+       │
+       ▼
+HTTP client        toolkit-http (hyper + rustls), outbound HTTPS only, built once per
+                   source plugin via the shared bss-rate-provider-sdk::http_client helper
+                   → ECB eurofxref-daily.xml (primary) · bank/PSP feed (fallback, post-v1 O-10)
+```
+
+Shared source utilities (exact-decimal conversion, HTTP-error mapping, fetch metrics, the
+shared HTTP client builder, the `PluginV1` registration helper) live in
+`bss-rate-provider-sdk`, used by every source plugin and the core gear alike.
+
+The ledger-side `RateSyncJob` (outside this boundary) resolves the registered composite
+instance the same way this gear resolves its own sources — a types-registry lookup +
+scoped `ClientHub` get, matched by the ledger's `fx.provider_vendor` — then calls
+`fetch_latest(ctx, &[], request_id)` once per tick and persists each returned rate under
+the `provider` that rate carries. The composite's own `provider_id()` is its constant
+configured identity, used for log attribution only, never as a row stamp. (The exact
+ledger-side resolution code is out of this gear's boundary and not re-verified here — see
+the ledger's own design docs.)
+
+## 2. Principles & Constraints
+
+### 2.1 Design Principles
+
+#### Fetch-only adapter
+
+- [ ] `p1` - **ID**: `cpt-cf-bss-rate-provider-principle-fetch-only`
+
+The gear fetches rates and nothing else: no persistence, no translation, no triangulation,
+no staleness marking, no snapshotting — those are ledger-owned (§1.1). `fetch_latest` MUST
+be side-effect-free and safe to call repeatedly (the ledger job is idempotent).
+
+#### Config-driven source assembly
+
+- [ ] `p1` - **ID**: `cpt-cf-bss-rate-provider-principle-config-driven-assembly`
+
+The active sources and their fallback order are config — the composite is assembled lazily
+by discovery, never hardcoded. Each source is its own deployed plugin gear with a `vendor` +
+`priority` in its config; add a source by deploying/configuring its plugin gear, remove one
+by un-configuring it, reorder the fallback chain by changing `priority` values. A new
+provider *family* costs one new plugin crate implementing `RateProviderV1`; a new *simple
+REST feed* costs zero code — configure `bss-rate-provider-http-json-plugin` with a
+`mapping`.
+
+#### One source per document — provenance, not coverage
+
+- [ ] `p1` - **ID**: `cpt-cf-bss-rate-provider-principle-single-source-provenance`
+
+**Normative rule, stated once so the two halves are not read as competing:** a served
+document comes from exactly **one** source, taken **whole**, never stitched together across
+sources — and **coverage is not a success criterion**. Those are one rule about *provenance*,
+not two rules in tension. Concretely:
+
+| A source returns | Result | Fallback to the next source? |
+|---|---|---|
+| Some pairs, some entries skipped as invalid | `Ok` with the survivors | **No** — partial coverage is a success |
+| Fewer pairs than the ledger would like | `Ok` with what it publishes | **No** |
+| Nothing usable (every entry failed) | `Err(Internal)` | Yes |
+| Requested pairs matched nothing it publishes | `Err(PairUnavailable)` | Yes |
+| Transport / status / whole-document parse failure | `Err` | Yes |
+
+So fallback triggers only when a source returns `Err` for the **whole fetch** — never per
+missing pair, never a cross-source merge. A pair absent from the chosen source's document is
+simply absent (the ledger treats it as no rate). A snapshot period stays
+single-source-coherent for audit (O-1).
+
+Read the older phrasings — "first whole document", "all-or-nothing per source" — strictly as
+this provenance rule. Neither is a completeness rule. A source that publishes 20 of the 30
+pairs the ledger would like returns those 20 and succeeds; a single entry that fails to
+convert is skipped and the rest of the document still serves (§3.2, both sources). **Per-pair
+fallback does not exist in v1** and is explicitly deferred (O-1 variant (b), O-13).
+
+**Why a coverage gate was rejected, not merely left out.** The two shapes such a gate could
+take — "all requested pairs" or "an explicit minimum expected set" — each fail on their own:
+
+- *All requested pairs* has nothing to bind to on the real call path. The ledger's
+  `RateSyncJob` calls `fetch_latest(&[])` — the whole published table, no requested pairs — so
+  the gate would be vacuous exactly where the rates actually come from. Where pairs *are*
+  passed, ECB publishes EUR-based pairs only, and a pair it does not publish is omitted by
+  design ("Direct pairs only" below, O-3); requiring completeness would fail the document on
+  every non-EUR-base pair the ledger asks about.
+- *A minimum expected set* would have to be configured per source and kept in step with what
+  each feed publishes — an operator-maintained duplicate of the feed's own contents, wrong the
+  first time a currency is added or delisted upstream, and wrong in the direction that blocks
+  a usable document.
+
+And both would make the failure mode worse rather than better. The ledger's `RateSyncJob`
+turns ANY error from a configured provider into `FX_SNAPSHOT_MISSING` and refreshes
+**nothing**, so one delisted currency or one malformed value would stall the FX fan-out for
+every other currency in an otherwise-usable feed — trading a few stale pairs for all of them.
+Falling through to a lower-priority source does not repair the gap either: the composite
+serves that source's document *whole*, so a feed with narrower coverage can leave the ledger
+with strictly fewer refreshed pairs than the primary it replaced.
+
+Partial coverage is not silent either. The skipped entries are logged individually with a
+reason plus an aggregate count, and a pair that stops being refreshed ages out under the
+ledger's own staleness window into `FX_RATE_UNAVAILABLE` — so the platform still surfaces it,
+through the layer that owns the age policy. The one case that *is* an error is a document
+where **nothing** usable survives: all entries failed conversion (`Internal`), or the
+requested pairs matched nothing this source publishes
+([`RateProviderError::PairUnavailable`]) — both `Err`, so the composite moves on.
+
+#### Direct pairs only
+
+- [ ] `p1` - **ID**: `cpt-cf-bss-rate-provider-principle-direct-pairs-only`
+
+A source emits only its natively published pairs, never synthesized — cross-base derivation
+is the ledger's triangulation concern (O-3). A requested pair the source cannot serve is
+**omitted** from the returned document; if that leaves the document empty, the source
+returns [`RateProviderError::PairUnavailable`] naming the first requested pair.
+
+This is one contract for both source plugins. `PairUnavailable` rather than `Internal`
+because it is a routine "not served here", not a fault in this gear — the distinction is
+visible on `fx_provider_fetch_errors_total{kind}`, where these must not be counted as
+`internal` and hide real defects. An `Err` rather than `Ok([])` because an empty document
+reads as a complete answer and would stop the fallback chain on the first source, when the
+next one may publish exactly that pair.
+
+Whole-table calls (empty `pairs`, which is what the ledger's sync job makes) are unaffected:
+with no requested pair there is nothing to report unavailable — `PairUnavailable` simply
+never applies. `Ok([])` is still unreachable on that path: a document with no usable
+entries fails as `Internal` (ECB rejects a zero-entry table at parse time, http-json
+errors when nothing maps), so no source can pass an empty table off as a complete answer.
+
+#### Deterministic conversion
+
+- [ ] `p1` - **ID**: `cpt-cf-bss-rate-provider-principle-deterministic-conversion`
+
+`rate → rate_micro` conversion parses the published decimal into an **exact decimal
+representation** (never binary floating point) and rounds with banker's rounding
+(half-to-even), matching the platform ledger rounding default, so a re-fetch of the same
+published rate yields the same integer (§3.2, O-4).
+
+#### Provider time, not fetch time
+
+- [ ] `p1` - **ID**: `cpt-cf-bss-rate-provider-principle-provider-as-of`
+
+`as_of` MUST be the provider's publication timestamp normalized to UTC — never `now()`.
+On non-publication days (weekends / TARGET holidays) the last published rate is returned
+with its original `as_of`, so the ledger's staleness rule still applies.
+
+**Bounded in the future direction, unbounded in the past.** The ledger's staleness rule is
+`now - as_of` against a window, which only constrains the past. A document dated ahead of us
+has a *negative* age and reads as permanently fresh, so a feed publishing a month-ahead
+timestamp would keep the ledger locking a frozen rate with no staleness alarm ever firing.
+Each source therefore rejects a document whose `as_of` is more than
+`MAX_FUTURE_SKEW_HOURS` = 26 h ahead of the gear's own clock
+(`bss_rate_provider_sdk::publication_time`), at parse time, before any rate is built:
+
+- **Owned by the source plugin, not the ledger.** Once a rate is a stored row the ledger
+  cannot tell "the feed published a bad timestamp" from "we have not synced in a while";
+  only the plugin sees the value arrive off the wire on this tick.
+- **Fail-safe.** The rejection fails the whole document, so the composite falls through to
+  the next source rather than storing the bad value — the same shape as any other parse
+  rejection, and it counts on `fx_provider_fetch_errors_total{kind="internal"}`.
+- **26 h = 14 h + 12 h.** 14 h is the widest civil timezone offset (UTC+14), so a date-only
+  feed like ECB — whose date its plugin anchors at 00:00:00 UTC — is never rejected for
+  being dated in its own timezone; 12 h is a generous host-clock-drift allowance, so a local
+  NTP failure degrades into wrong-but-served instead of a feed-wide outage.
+- **Nothing is rejected for being old.** Age is the ledger's policy; re-checking it here
+  would put one rule in two layers and let them disagree.
+
+### 2.2 Constraints
+
+#### Fixed SDK contract
+
+- [ ] `p1` - **ID**: `cpt-cf-bss-rate-provider-constraint-fixed-sdk-contract`
+
+The `RateProviderV1` trait, `ProviderRate`, `CurrencyPair`, and `RateProviderError` are
+**already defined** in `bss-ledger-sdk` and MUST NOT be changed without a ledger-side
+change (GTS `gts.cf.bss.ledger.rate-provider.v1`).
+
+#### Never on the posting path
+
+- [ ] `p1` - **ID**: `cpt-cf-bss-rate-provider-constraint-off-posting-path`
+
+`fetch_latest` is called only by the background `RateSyncJob`. A provider outage fails the
+job (ledger alarms), never a post. The adapter MUST NOT retry indefinitely; one bounded
+attempt per call — the ledger job schedules the next tick.
+
+**Why no same-source retry before falling back.** Any `Err` from a source advances the
+chain; there is no retriable/non-retriable classification in v1, and that is deliberate
+rather than unfinished:
+
+- **A second attempt buys little here.** The chain already provides the retry, against a
+  *different* upstream. Source diversity beats attempt count for the failures that actually
+  happen — a feed being down, rate-limiting, or a bad deploy on the publisher's side are all
+  things an immediate retry to the same host does not fix.
+- **The background rescheduling is the real retry.** The next tick re-runs the whole chain
+  within `rate_sync_tick` (1 h default), far inside the 24 h G10 staleness window, so a
+  transient failure costs a refresh, not a posting outage.
+- **It keeps the latency budget honest.** Worst case stays the sum of the per-source
+  timeouts (see the fetch-budget rule in §2); adding R retries would multiply it by R and
+  make the budget rule much easier to breach by accident.
+
+Classification may be worth adding later, and the case for it is narrow: `UpstreamStatus`
+with a `429`/`503` plus a `Retry-After` inside the tick budget is the one signal that says
+"the same source will work shortly". `Unreachable` (timeout, DNS, TLS) should keep falling
+straight through — those are precisely when another source is the faster answer.
+`PairUnavailable`, `InvalidPair`, and `Internal` are never retriable: retrying cannot change
+what a feed publishes or fix a local fault.
+
+#### Stateless
+
+- [ ] `p1` - **ID**: `cpt-cf-bss-rate-provider-constraint-stateless`
+
+The adapter holds no DB, no per-tenant state, and — since provenance moved onto each
+`ProviderRate` — no in-memory state at all: the composite is rebuilt per call and every
+source's fields are set once at `init()`. A provider publishes **global** rates and the
+ledger fans them out per tenant.
+
+#### Fail-safe by absence
+
+- [ ] `p1` - **ID**: `cpt-cf-bss-rate-provider-constraint-fail-safe-by-absence`
+
+If the adapter is not registered, the ledger uses `UnconfiguredRateProviderV1` → the local
+store stays empty → FX posts block (`FX_RATE_UNAVAILABLE`), never a silent wrong rate.
+
+#### Rate precision
+
+- [ ] `p1` - **ID**: `cpt-cf-bss-rate-provider-constraint-rate-micro-precision`
+
+`ProviderRate.rate_micro` is the functional-per-unit-transaction multiplier × 1e6, `i64`
+(O-5: kept for v1; revisit for high-unit / crypto pairs — any change is an SDK change).
+Overflow / non-finite values MUST map to `RateProviderError::Internal`, never a silent
+truncation.
+
+**`rate_micro` MUST be strictly positive** (`> 0`) — a rate that rounds to zero or below is
+rejected at conversion, not stored. Confirmed with the BSS billing owner (2026-07-28): the
+domain has no negative or zero FX rates, so accepting one would only ever mean corrupt feed
+data, and it would zero out or flip the sign of every translation derived from it. The
+ledger's `RateSyncJob` independently drops non-positive quotes before upsert, so this is the
+outer of two gates rather than the only one.
+
+#### Secrets handling
+
+- [ ] `p1` - **ID**: `cpt-cf-bss-rate-provider-constraint-secrets`
+
+Any provider API key MUST come from config `${VAR}` expansion or the platform CredStore —
+never hardcoded, never logged, never in this document. Implemented as `secrecy::SecretString`
+carried by the `auth` enum variant that needs it (`bss-rate-provider-http-json-plugin`'s
+`Auth::Bearer { api_key } | Auth::HeaderKey { api_key }` — the same `SecretString` pattern
+`authn-resolver`'s plugin configs use) so an accidental `Debug`/`tracing` dump of the
+config struct is redacted rather than printing the key — only `expose_secret()` reveals it,
+at the one call site that builds the outbound auth header. Binding the credential to the
+variant also removes the "configured to authenticate but no key" and "key set but never
+sent" states entirely (§3.2). ECB has no credential (public feed).
+
+**How `${VAR}` is realized.** The http-json plugin loads its config through
+`ctx.config_expanded()`, and `Auth` implements `ExpandVars` by hand (the derive covers only
+structs with named fields, and the credential deliberately lives inside an enum variant), so
+`api_key: "${BANK_X_KEY}"` is resolved from the environment at `init()`. An unresolvable
+variable **fails `init()`** rather than letting the source start up and send the literal
+placeholder as its credential. This is what makes the gap below survivable in practice: the
+raw key never has to be written into the config file that the dump serializes.
+
+**CredStore is not wired.** The platform CredStore is named above as an allowed source of the
+credential, but this gear has no CredStore integration — `${VAR}` expansion is the only
+implemented path today. Adding one is a separate change, and not a prerequisite: `${VAR}`
+already keeps the key out of the config file.
+
+**Gap — raw effective-config dumps are not covered.** `SecretString` redacts the *typed*
+config once deserialized into Rust. It does not reach `toolkit`'s own effective-config dump
+(`toolkit::bootstrap::config::dump`), which serializes the **pre-deserialization** JSON, so a
+routine diagnostic can print an `api_key` verbatim.
+
+- **Normative:** raw configuration output MUST redact credential-shaped fields (or refuse to
+  emit sections containing them). A gear cannot satisfy this from its own side — by the time
+  the value reaches a gear's typed config the dump has already run — so it MUST be enforced
+  inside the dump.
+- **Owner:** the platform / `toolkit` maintainers, not this gear. Recorded here because this
+  gear is the one that supplies it a credential to leak; tracked as a risk in PRD §12.
+- **Scope today:** not exploitable in v1 as shipped. The only configured source is ECB, a
+  public feed with no credential, so there is nothing in this gear's config for a dump to
+  disclose. The documented `${VAR}` path (above) keeps the raw key out of the file the dump
+  serializes, but it is a convention, not an enforced guarantee — so dump-side redaction is
+  a **p1 prerequisite for enabling credential-bearing feeds** (tracked as a p1 dependency
+  in PRD §10 and as the §12 risk): no authenticated http-json feed is onboarded until the
+  dump redacts credential-shaped fields.
+
+## 3. Technical Architecture
+
+### 3.1 Domain Model
+
+The domain types are **inherited from `bss-ledger-sdk`** (`rate_provider.rs`) and NOT
+redefined here (constraint `cpt-cf-bss-rate-provider-constraint-fixed-sdk-contract`).
+
+#### Type: `CurrencyPair`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `base` | string (ISO 4217) | Yes | Transaction currency |
+| `quote` | string (ISO 4217) | Yes | Functional currency |
+
+#### Type: `ProviderRate`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `base` | string | Yes | Base (transaction) currency |
+| `quote` | string | Yes | Quote (functional) currency |
+| `rate_micro` | int64 | Yes | Functional-per-unit-base × 1e6 (fixed precision) |
+| `as_of` | timestamp (UTC) | Yes | Provider publication time; drives ledger staleness |
+| `provider` | string | Yes | The concrete upstream that published THIS rate, stamped by the serving source; what the ledger stores as `ledger_fx_rate.provider` (see the provenance rule in §3.2) |
+
+#### Enum: `RateProviderError`
+
+| Value | Description |
+|-------|-------------|
+| `PairUnavailable { base, quote }` | Provider does not publish this pair |
+| `Unreachable(msg)` | Network / DNS / timeout |
+| `UpstreamStatus(u16)` | Non-success HTTP status |
+| `InvalidPair(msg)` | Malformed / unknown currency code |
+| `Internal(msg)` | Parse / conversion fault |
+
+### 3.2 Component Model
+
+Each component carries a stable `cpt-cf-bss-rate-provider-component-{slug}` ID.
+
+#### Plugin discovery & per-plugin configuration
+
+- [ ] `p1` - **ID**: `cpt-cf-bss-rate-provider-component-source-factory`
+
+There is no `build_source` factory and no `kind` field — each source is its own gear crate
+implementing `RateProviderV1` directly, and "assembly" is types-registry discovery, not a
+config-driven factory loop:
+
+- Each source-plugin gear's `init()` registers a `PluginV1<RateProviderSourcePluginSpecV1>`
+  instance (carrying its own `vendor` + `priority` in the instance JSON) and a scoped
+  `RateProviderV1` client keyed by that instance's GTS id
+  (`bss_rate_provider_sdk::registration::register_rate_provider_plugin`, shared by every
+  plugin gear including the core gear itself).
+- The core gear's `DiscoveringRateProvider` (built at `init()`, discovery deferred to the
+  first `fetch_latest`) lists all `RateProviderSourcePluginSpecV1` instances, **keeps only
+  the ones whose `vendor` matches its own configured `source_vendor`**, sorts the survivors
+  by `priority` (lower = tried first; a tie is broken by the plugin's GTS **instance id**,
+  and logged as a warning, never a startup failure), and resolves each via `get_scoped`. A
+  vendor match whose scoped client isn't registered is logged and excluded, not fatal.
+  The tiebreak is deliberate: registry list order is not a stable contract, so ordering on
+  it would let the serving source — and with it the provenance written onto financial rows
+  — change between ticks with no configuration change. Sharing a `priority` is still
+  flagged, because the id then decides an order nobody chose for that purpose.
+- **Empty result is a *runtime* error, not a startup failure.** If zero source plugins match
+  the configured vendor, `discover()` returns `RateProviderError::Unreachable` from that
+  *tick's* `fetch_latest` — it is **not** checked or rejected at any `init()`, because
+  discovery itself doesn't run until the first fetch (deliberately, so plugin registration
+  order across gears never matters — see O-7 revised). This is a real behavior change from
+  the original (pre-plugin-pattern) design, which required a startup-time empty-list check
+  — there is no equivalent of "unknown `kind`" or "empty `sources[]`" to validate anymore,
+  since there is no `kind` and no list.
+- **Discovery re-runs on every tick, not just the first.** Neither a successful nor a
+  failed discovery is cached across calls — every `fetch_latest`/`health` re-lists
+  instances and rebuilds the composite from scratch. A source plugin that registers,
+  deregisters, or changes its `priority` between ticks takes effect on the very next tick,
+  never requiring a gear restart (§3.8 "Deployment Topology"). A *failed* discovery (zero
+  matches) is **not** papered over with a retained composite: `fetch_latest` returns the
+  no-sources error for that tick (§3.2), the ledger job alarms, and the next tick re-runs
+  discovery from scratch. Nothing about source identity survives a call — `provider_id()` is
+  the core gear's own constant configured id, and the serving source is carried per rate
+  (O-7a), so there is no "last real upstream" state to keep.
+  This trades one `list_instances` call per tick (hourly, per the PRD's default
+  `fx.rate_sync_tick_secs`) for always-current membership — negligible overhead for a
+  background job that never runs on the posting path.
+- There is likewise no `fx.provider_order` list to align — cross-gear alignment between the
+  core gear, its source plugins, and the ledger is a shared **`vendor` string** match (O-12
+  revised), not an ordered-list comparison.
+
+**Module config — one block per gear, not one list:**
+
+```yaml
+gears:
+  bss-rate-provider:                    # the core/composite gear
+    config:
+      vendor: "cf.bss"                  # what THIS composite advertises to the ledger
+      priority: 100
+      source_vendor: "cf.bss"           # which source plugins this gear composes
+      id: "bss-rate-provider"           # provider_id() — constant, never a served source
+
+  bss-rate-provider-ecb-plugin:
+    config:
+      id: "ecb"                         # stable provider_id stamped on synced rows
+      vendor: "cf.bss"                  # MUST match the core gear's source_vendor
+      priority: 100                     # lower = tried first
+      base_url: "https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml"
+      timeout_ms: 5000
+
+  bss-rate-provider-http-json-plugin:   # ILLUSTRATIVE fallback — not part of v1 (O-10: v1 ships ECB-only)
+    config:
+      id: "bank-x"
+      vendor: "cf.bss"
+      priority: 200
+      base_url: "${BANK_X_URL}"
+      timeout_ms: 5000
+      # The credential lives INSIDE `auth`, on the variant that needs it. Omit
+      # the whole `auth:` block for a public feed. `kind: none` takes no
+      # api_key, and bearer/header-key REQUIRE one — both enforced by serde at
+      # config load, not by a runtime check.
+      auth:
+        kind: bearer                   # none | bearer | header-key
+        api_key: "${BANK_X_KEY}"       # SecretString — never logged
+      mapping:
+        base: "USD"                    # v1: literal base only, no JSON-path base
+        rates: "rates"                 # dotted path, not a JSON-path/JSONPath expression
+        rate: "value"
+        as_of: "date"
+```
+
+**Config fields, by gear (no shared `SourceConfig` type — each plugin's config is its own
+struct; the `id`/`vendor`/`priority` shape is a convention every plugin repeats, not a
+common base type):**
+
+| Gear | Field | Type | Required | Description |
+|------|-------|------|----------|-------------|
+| all three | `id` | string | Yes | Core gear: the composite's own constant `provider_id()` (log/alarm attribution). Plugins: the stable per-rate `provider` stamped on every rate they serve. |
+| all three | `vendor` (core), `source_vendor` (core, source-selection), `vendor` (plugins) | string | Yes | The matching key across core ↔ plugins ↔ ledger `fx.provider_vendor`. |
+| all three | `priority` | i16 | Yes | Fallback order (lower tried first); duplicates across plugins are logged, not rejected. |
+| plugins only | `base_url` | string | Yes | Source endpoint; must parse as a URL with the `https` scheme (case-insensitive) and a host — checked at that plugin's `init()`. |
+| plugins only | `timeout_ms` | u64 | No (5000) | Outbound per-attempt HTTP timeout. |
+| http-json only | `auth` | tagged enum: `{kind: none}` \| `{kind: bearer, api_key}` \| `{kind: header-key, api_key}` | No (`none`) | How the feed is authenticated **and** the credential it needs, in one value. `api_key` is a `SecretString` (`${VAR}` / CredStore expansion upstream, redacted from `Debug`). A kind that needs a key without one, or a key attached to `none`, is a **config-load error** — the invalid combinations are unrepresentable rather than runtime-checked. |
+| http-json only | `mapping` | struct, optional | **Yes for http-json** — its `init()` fails loud if absent | `base` (literal only, must be ISO-4217-shaped), `rates`/`rate`/`as_of` (dotted paths). |
+
+**Adding a provider:**
+
+- *Simple REST feed* → deploy/configure `bss-rate-provider-http-json-plugin` with a
+  `mapping` and a `vendor` matching the core gear's `source_vendor`. **No code.**
+- *New family (quirky format/auth)* → implement `RateProviderV1` in a new plugin crate,
+  register it the same way (`register_rate_provider_plugin`), give it a matching `vendor`.
+
+#### `CompositeRateProvider`
+
+- [ ] `p1` - **ID**: `cpt-cf-bss-rate-provider-component-composite`
+
+**Not itself the registered `ClientHub` instance** — `DiscoveringRateProvider` (see §1.3) is
+what the core gear registers; it rebuilds a fresh `CompositeRateProvider` on every
+`fetch_latest`/`health` call, never reusing one across ticks. `CompositeRateProvider` wraps
+the **ordered** `Vec<Arc<dyn RateProviderV1>>` that discovery produced and does the fallback
+the ledger cannot. Source-agnostic — it never names a concrete source. Configuration: none of
+its own beyond the composite's `id` — the try order **is** the priority order that tick's
+`discover()` established; a `priority` config change on a source plugin takes effect on the
+*very next tick*, no restart needed.
+
+**State:** none. The composite is a stateless value rebuilt per call — no `last_served`
+index, no interior mutability, no persistence.
+
+| Operation | Input | Output | Key Behavior |
+|-----------|-------|--------|--------------|
+| `fetch_latest` | `ctx`, `pairs`, `request_id` | `Vec<ProviderRate>` | Try sources **in order**; return the **first** that yields `Ok(document)` **whole** (no merge), unchanged — each rate already carries its own `provider`. If **all** sources fail, return the last `RateProviderError` (the ledger job then raises `FX_SNAPSHOT_MISSING`). |
+| `provider_id` | — | `&str` | The composite's own **constant** id (the core gear's configured `id`), for log/alarm attribution. NOT the last-served source — see the provenance rule below. |
+| `health` | `ctx`, `request_id` | `()` | `Ok(())` if **any** source is reachable (ordered probe, short-circuits on the first success). `Err` only when every source's probe failed, and then it is the last source's error — the same ordering caveat as `fetch_latest`. |
+
+**Behavioral rules:**
+
+- **Provenance is per-rate, never read back through `provider_id()`.** Each source stamps
+  its own id onto every [`ProviderRate`] it returns (§3.1), so the serving upstream travels
+  with the data and the ledger records it per row. `provider_id()` MUST NOT be used to
+  answer "who served the batch I just fetched?": it carries no information about which
+  `fetch_latest` it relates to, and the composite is registered process-wide in `ClientHub`,
+  so a second consumer fetching in between would make the ledger stamp the wrong source onto
+  financial records. The ledger's `RateSyncJob` therefore does not depend on call ordering
+  for correctness (O-7a).
+- **Empty-list safety.** The constructor only `debug_assert!`s non-emptiness (a defensive
+  invariant check that compiles out in release). `provider_id()` reads no element of the
+  source list at all, so it cannot index out of bounds; `fetch_latest`/`health` return an
+  "empty composite" `Internal` error. Both are covered by unit tests that construct the
+  struct directly, bypassing the debug-only guard.
+
+#### `EcbRateProvider` (source plugin `bss-rate-provider-ecb-plugin`)
+
+- [ ] `p1` - **ID**: `cpt-cf-bss-rate-provider-component-ecb-source`
+
+HTTP fetch + XML parse + `rate_micro` conversion + error mapping over the ECB daily feed.
+Dependencies: its own `toolkit_http::HttpClient` (built once in this plugin's `init()` via
+the shared `bss_rate_provider_sdk::http_client::build_source_http_client` helper — not a
+process-wide shared client), its own `EcbPluginConfig` (`id` default `"ecb"`, `vendor`,
+`priority`, `base_url` default = the ECB daily feed, `timeout_ms` default `5000`).
+
+**No `format` field exists.** v1 ships **XML-only** (`parse_ecb_xml`) — there is no `format`
+config knob and no SDMX parser in the implementation; O-2's "SDMX optional" / "Frankfurter
+allowed for dev" were never built. Add a `format` field only if a non-XML feed is actually
+needed.
+
+| Operation | Input | Output | Key Behavior |
+|-----------|-------|--------|--------------|
+| `provider_id` | — | `&str` | Returns the configured stable id. |
+| `fetch_latest` | `ctx`, `pairs: &[CurrencyPair]`, `request_id` | `Vec<ProviderRate>` | GET latest feed → parse → convert, stamping each rate with this source's `id`. `pairs = &[]` ⇒ return the **whole** published table. Requested pairs the source cannot serve are **omitted** (not an error). Map transport failures to `Unreachable` / `UpstreamStatus`. |
+| `health` | `ctx`, `request_id` | `()` | A cheap `HEAD` against the same feed URL — never re-parses the published table just to check reachability. **Any HTTP response is `Ok(())`**, including a non-2xx: the status is logged, not returned as a failure, since a `503` proves the request arrived. Only a transport failure (DNS / connect / TLS / timeout) is `Err`. |
+
+**ECB payload handling:**
+
+- **Direct pairs published by ECB are EUR-based** (EUR→X). A `CurrencyPair` whose
+  `base`/`quote` is not directly published is **omitted** — never synthesized (O-3). In
+  particular the **inverse leg X→EUR is NOT emitted here** (e.g. `USD→EUR` for a USD
+  transaction under an EUR functional currency): deriving it by **deterministic inversion**
+  of the stored EUR→X rate is part of the ledger's triangulation (O-3; §4 "Companion
+  ledger change").
+- **Currency codes are gated on the ISO-4217 shape.** The `currency` XML attribute arrives
+  verbatim from the remote feed and becomes a tenant-store column value, so a code that
+  isn't three ASCII letters is dropped and logged; survivors are uppercased, and dedup keys
+  off the normalized code (so a feed publishing both `USD` and `usd` is caught as the
+  duplicate it is). Dropping every entry surfaces the documented empty-table `Internal`
+  error rather than an empty `Ok`.
+- **Two distinct publication dates fail the whole document.** The daily feed is, by
+  contract, one day's rates; a second `<Cube time=…>` with a different date means this is not
+  that file — overwhelmingly the likely cause is a `base_url` pointing at ECB's 90-day
+  history feed. There is no non-arbitrary way to choose between the dates, and picking one by
+  document order would silently serve one day's slice of some other file under a date that
+  depends on parse order. The rejection is an `Internal` naming both dates, so the composite
+  falls through to the next source (fail-safe) and the operator sees the collision. A repeat
+  of the **same** date is not a conflict and is accepted.
+- **A currency row is bound to its own `<Cube time=…>` block.** Rows under a `time` that
+  failed to parse, or with no enclosing date at all, are omitted rather than folded into the
+  document's table under an `as_of` that isn't theirs. An unparseable `time` is logged with
+  its raw value, so the eventual "missing publication date" error isn't the only clue. A
+  `Cube` carrying only one of `currency`/`rate` (a truncated feed row) is likewise logged and
+  ignored — no anomaly in this parser is dropped silently.
+- **An unconvertible rate is skipped per entry, not fatal for the document** — matching the
+  http-json source. This is the normative semantic, not an exception to §2.1's "one source per
+  document": that rule governs *provenance*, and coverage is deliberately not a success
+  criterion (§2.1, O-13). This matters beyond consistency: the ledger's `RateSyncJob` turns ANY
+  failure from a *configured* provider into `FX_SNAPSHOT_MISSING` and refreshes nothing, so
+  failing the batch over one malformed value would stall the FX fan-out for every other
+  currency in an otherwise-usable feed. Each skip is logged with its quote and reason, plus
+  an aggregate count. The document is reported as `Internal` only when entries were
+  attempted and **all** of them failed; an empty result because a non-empty requested-`pairs`
+  filter matched nothing is `PairUnavailable` (the shared "not served here" contract under
+  §2.1 "Direct pairs only"), never `Ok(vec![])`.
+- **Non-publication days** (weekends / TARGET holidays): return the last published rate
+  with its original `as_of` (staleness is the ledger's call).
+- **Cadence assumption:** ECB publishes once per TARGET business day ~16:00 CET; on
+  non-publication days the last published rate is returned (its `as_of` unchanged, so the
+  ledger's staleness rule still applies).
+
+#### `HttpJsonRateProvider` (source plugin `bss-rate-provider-http-json-plugin`)
+
+- [ ] `p2` - **ID**: `cpt-cf-bss-rate-provider-component-http-json-source`
+
+A configurable GET-JSON source so a plain REST rate feed is onboarded by **config alone**.
+Covers the common "fetch a JSON document of rates, map fields" shape; NOT for quirky
+sources (ECB XML above, or a PSP settlement feed with signed auth — those get their own
+plugin crate). Dependencies: its own `toolkit_http::HttpClient` (same shared builder helper
+as ECB); its own `HttpJsonPluginConfig` incl. `mapping` + `auth` (the `api_key` lives
+*inside* the credential-bearing `auth` kinds, never as a top-level field — see the
+configuration table below).
+
+**Configuration (`HttpJsonPluginConfig`, in addition to `id`/`vendor`/`priority`/
+`base_url`/`timeout_ms`):**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `mapping.base` | string, **literal only** | — | Base currency literal (e.g. `"USD"`) — v1 has no path-based/multi-base support, only a fixed literal. |
+| `mapping.rates` | dotted path (`a.b.c`, object traversal only — not JSONPath) | — | The object of quote→entry pairs. |
+| `mapping.rate` | field name within each entry | — | The numeric/string rate field. |
+| `mapping.as_of` | dotted path | — | Publication timestamp (RFC 3339); parsed to UTC. One document-level timestamp is applied to every returned rate — there is no per-entry `as_of`. |
+| `auth` | tagged enum (see §3.2's config table) | `{kind: none}` | How the feed is authenticated, carrying its credential: `Authorization: Bearer …` or a fixed `X-API-Key` header. |
+
+| Operation | Input | Output | Key Behavior |
+|-----------|-------|--------|--------------|
+| `fetch_latest` | `ctx`, `pairs`, `request_id` | `Vec<ProviderRate>` | GET `base_url` (with `auth`) → parse JSON → apply `mapping` → convert each to `ProviderRate` stamped with this source's `id`. `pairs = &[]` ⇒ whole document; a non-empty `pairs` filters **case-insensitively** (matching the ECB source). An entry that fails mapping is skipped (logged with its quote + reason, plus an aggregate count), never fabricated; a document where **zero** entries map ⇒ `RateProviderError::Internal` (behavioral rules below). |
+| `provider_id` | — | `&str` | The configured `id`. |
+| `health` | `ctx`, `request_id` | `()` | A `HEAD` against the configured `base_url`, carrying the same credential the fetch uses, with the identical rule as ECB: any HTTP response is `Ok(())`, only a transport failure is `Err`. That rule is what makes a HEAD usable here at all — an arbitrary JSON API commonly answers `405` to HEAD while serving `GET`, and `401`/`403` on a rotated key; all three are the host answering. Records **no** fetch metrics: touching them would advance the last-success gauge and mask the freshness alerts. |
+
+**Behavioral rules:**
+
+- **Base-currency shape.** Many free feeds are single-base. Config states the base; a
+  requested pair whose base ≠ the feed base is **omitted**, never synthesized here (O-3).
+  If filtering leaves nothing at all, that is `RateProviderError::PairUnavailable` — the
+  same answer the ECB source gives — not `Ok([])`, so the composite falls back instead of
+  recording a served-but-empty tick.
+- **Pair matching is case-insensitive**, the same as the ECB source. Both sit behind one
+  composite, so a caller passing `"usd"` must not get rates from one source and an empty
+  result from the other purely because of casing.
+- **Currency codes are gated on the ISO-4217 shape** (three ASCII letters, uppercased)
+  before they can reach a tenant's store: a malformed `quote` from the feed is skipped like
+  any other unmappable entry, while a malformed configured `mapping.base` fails the whole
+  document — it is operator config, not feed data, and would taint every rate.
+- **Deterministic mapping.** An unresolvable field ⇒ skip that entry with a logged reason
+  (a success for the document — coverage is not a success criterion, §2.1 / O-13);
+  a wholesale parse failure ⇒ `RateProviderError::Internal`. A syntactically
+  valid document from which **zero entries map** MUST also return
+  `RateProviderError::Internal` — returning `Ok([])` would read as success, suppress the
+  composite fallback, and let the ledger mark the sync pass successful without refreshing
+  a single rate.
+- **Scope (O-11):** v1 = single-base JSON feeds, simple field paths,
+  `none` / `bearer` / `header-key` auth; richer transforms (multi-base, JSON-path dialects,
+  custom date/number formats) deferred.
+
+#### `rate → rate_micro` conversion
+
+- [ ] `p1` - **ID**: `cpt-cf-bss-rate-provider-component-rate-micro-conversion`
+
+ECB quotes ~5 significant digits. Convert `rate` (decimal) to
+`rate_micro = round(rate × 1_000_000)` using **banker's rounding (half-to-even)** to match
+the platform ledger rounding default, so a re-fetch of the same published rate yields the
+same integer (O-4: accepted — half-to-even is inherited from the ledger's platform default
+`cpt-cf-bss-ledger-fr-money-rounding-scale`, not chosen here; any revision would come from
+that requirement changing, not from this gear).
+The published decimal string MUST be parsed into an **exact decimal representation** —
+**never a binary `f64`**, whose nearest-representable value can mis-round exact half-way
+decimals under half-to-even. Implemented with `rust_decimal::Decimal`
+(`Decimal::from_str_exact` → `checked_mul` by `1_000_000` → `round_dp_with_strategy(0,
+MidpointNearestEven)` → `to_i64()`), not an arbitrary-precision `BigDecimal` — `Decimal`'s
+fixed 96-bit mantissa is sufficient for FX-rate magnitudes and is the crate already used
+elsewhere in this codebase. Overflow / non-finite / non-numeric values MUST map to
+`RateProviderError::Internal` (never a silent truncation) — verified down to the exact
+`i64::MAX`/`i64::MIN` boundary in the unit tests.
+
+#### Gear wiring
+
+- [ ] `p1` - **ID**: `cpt-cf-bss-rate-provider-component-gear-init`
+
+**Crate layout** follows the repo's DDD-light gear structure — module wiring at the crate
+root, logic in a layer directory:
+
+```text
+rate-provider/src/         config.rs · module.rs · domain/composite.rs · infra/discovery.rs
+plugins/ecb-plugin/src/    config.rs · gear.rs   · infra/source.rs
+plugins/http-json-.../src/ config.rs · gear.rs   · infra/source.rs
+rate-provider-sdk/src/     flat — a library crate, not a gear, so no layer split
+```
+
+The split follows what each type actually depends on, not just "logic vs wiring":
+
+- **`domain/`** — `CompositeRateProvider` only. It holds nothing but the source *ports*
+  (`dyn RateProviderV1`) and the fallback policy over them, so it carries
+  `#[domain_model]`, which compile-time-proves no infrastructure type leaked in (and which
+  the `de0309` dylint requires of every externally-visible type in this layer).
+- **`infra/`** — `DiscoveringRateProvider` and both plugins' feed adapters.
+  `DiscoveringRateProvider` is deliberately NOT domain: it holds `Arc<ClientHub>` (a
+  service locator) and queries the types-registry over the wire, which is infrastructure by
+  intent even though those particular types aren't on the lint's deny-list.
+
+This matches the sibling plugin gears in this repo (`static-tr-plugin`,
+`static-authn-plugin`, `static-credstore-plugin` all keep a `src/domain/`).
+
+Three separate `#[toolkit::gear(...)]`-macro gears, each with its own `init()` and its own
+workspace/module registration — not one `init()` running a factory:
+
+- **`bss-rate-provider-ecb-plugin`** / **`bss-rate-provider-http-json-plugin`**: build their
+  own `toolkit_http::HttpClient`, construct their source, then call the shared
+  `bss_rate_provider_sdk::registration::register_rate_provider_plugin` helper to publish a
+  `PluginV1<RateProviderSourcePluginSpecV1>` instance + scoped `RateProviderV1` client.
+- **`bss-rate-provider`** (core): builds a `DiscoveringRateProvider` (no HTTP client of its
+  own — discovery only) and registers it via the *same* shared helper, keyed by
+  `RateProviderPluginSpecV1` instead.
+- All three share the `deps = [types_registry]` gear-macro edge (the types-registry gear
+  must exist as a dependency for the `#[toolkit::gear]` macro's init-ordering, though the
+  registration calls happen against `ClientHub` at runtime, not via that edge).
+
+Bank / PSP settlement feed: onboard via the generic `bss-rate-provider-http-json-plugin` if
+it is a plain REST feed, else a dedicated new plugin crate for signed/settlement auth
+(concrete feed is O-10: v1 = ECB-only; bank/PSP added later as one more deployed plugin
+gear, not a `sources[]` entry).
+
+### 3.3 API Contracts
+
+This gear exposes **no external REST surface** and produces **no events**. It is consumed
+in-process by the ledger via the `RateProviderV1` trait resolved from `ClientHub`
+(GTS `gts.cf.bss.ledger.rate-provider.v1`).
+
+| Surface | Direction | Contract | Notes |
+|---------|-----------|----------|-------|
+| `RateProviderV1::fetch_latest` | inbound (from ledger) | SDK trait | One round-trip per tick; `&[]` = whole table. |
+| `RateProviderV1::health` | inbound (from ledger) | SDK trait | Reachability **only** — never a freshness or readiness signal; see below. No caller in v1. |
+| ECB / bank feed | outbound | HTTPS GET | External provider; see §4 "Security & AuthZ". |
+
+**`health()` is reachability, and nothing more.** It answers "would a request to this feed's
+endpoint get through right now?", not "would the next sync produce usable rates?". A source
+can be `Ok` from `health()` while every real fetch fails on a malformed, empty, or
+wrongly-shaped body. Reading it as a liveness signal for the FX feed is therefore a mistake,
+and the contract is enforced by the trait rather than left to be inferred:
+
+- **`Ok(())` means the endpoint answered.** Any HTTP response counts, `4xx` and `5xx`
+  included: a `503` proves the request arrived, and a `405` is a normal reply from a feed that
+  does not accept the probe's method. Only a *transport* failure — DNS, connect, TLS, timeout
+  — is `Err`, because only then did nothing get through. Folding "is it serving correctly?"
+  into this call would make `Ok(())` mean something no cheap probe can establish, and would
+  report a `GET`-serving feed as down purely because it answers `405` to `HEAD`.
+- **No default implementation.** The trait requires `health()` of every adapter. An earlier
+  default delegated to `fetch_latest(&[])`, which gave any adapter that did not override it a
+  *parsing* health check by accident — one method carrying two different guarantees depending
+  on the vendor, so `Ok(())` could only be read as the weakest of them. Both sources now
+  implement the same cheap `HEAD` probe under the rule above, and a future source states its
+  own rather than inheriting one.
+- **The probe records no fetch metrics.** It deliberately bypasses `fetch_and_parse`. Letting
+  a probe touch those series would advance `fx_provider_last_success_timestamp` and the
+  fetch-duration count, silencing the freshness alerts below — a probe added to reveal an
+  outage would mask it instead.
+- **Freshness has its own signal.** A provider that is green on `health()` while every real
+  fetch fails shows up on `fx_provider_fetch_errors_total{provider}` — the errors keep
+  counting while `fx_provider_fetch_duration_seconds_count` does not move — and, once the
+  data itself ages out, on the `FxFeedStale` alert over
+  `fx_provider_last_success_timestamp{provider}` (§4 "Feature metrics"). Both are
+  source-independent: neither can be satisfied by a `HEAD`.
+- **Nothing consumes `health()` in v1.** The ledger's `RateSyncJob` calls only
+  `fetch_latest`; no gear, probe, or dashboard reads `health()`. The "green provider during a
+  sustained outage" failure mode therefore has no surface to appear on today. This note is
+  the contract for whoever wires it up first: pair it with the freshness alert, never
+  substitute it for one.
+
+**Relationship to the ledger's manual ingest.** The `RateProviderV1` pull driven by
+`RateSyncJob` is the **PRIMARY** rate path. The ledger separately exposes a **SECONDARY**
+manual/seed path — `POST /bss-ledger/v1/fx/rates` (ledger-owned, `(ledger, provision)` PEP
+gate) — that upserts one rate directly into `ledger_fx_rate`. This gear does **not** own or
+replace that endpoint; the two are complementary (automated feed vs manual break-glass /
+bootstrap).
+
+**Events.** Provider-outage signalling is the ledger's `RateSyncJob`, which emits
+`billing.ledger.invariant.alarm` with `alarmCategory = fx-snapshot-missing` (Critical) when
+a **configured** provider fails to fetch. The adapter only returns a `RateProviderError`;
+the ledger decides the alarm.
+
+An optional debug/liveness HTTP endpoint is deferred (O-6: metrics only for v1).
+
+### 3.4 Internal Dependencies
+
+- **`bss-ledger-sdk`** — the `RateProviderV1` trait and its types (`rate_provider.rs`); the fixed contract this gear implements.
+- **`bss-rate-provider-sdk`** — this gear's own shared internal crate: the source-plugin GTS spec, exact-decimal conversion, the ISO-4217 currency-shape gate, HTTP-error mapping, fetch metrics, the shared HTTP-client builder, and the `register_rate_provider_plugin` registration helper used by all four crates.
+- **`types-registry-sdk` / `types-registry`** — every plugin gear (including the core gear) registers a `PluginV1` instance here and the core gear queries it (`list_instances`) to discover source plugins; not used in the pre-plugin-pattern design.
+- **ToolKit `ClientHub`** — cross-gear registry; each gear `register_scoped`s its `RateProviderV1` under its own GTS instance id (never an unscoped registration).
+- **`toolkit-http`** — outbound HTTPS client (hyper + rustls under the hood); each source plugin builds its **own** instance via the shared builder helper — not one client shared by all sources.
+- **`secrecy`** — `SecretString` for the http-json plugin's `api_key` (ECB has no credential).
+- **Platform OTel meter** — each **source plugin** wires its own `OtelFetchMetrics` handle at `init()` from the process-global meter (§4 "Feature metrics"); the same instrument names coalesce across plugins. The core gear wires none — it emits no fetch instruments of its own (§4), so every fetch series is owned by the plugin that served the attempt.
+
+### 3.5 External Dependencies
+
+- **ECB reference rates** — primary source; free, published once per TARGET business day (`eurofxref-daily.xml`).
+- **Bank / PSP feed** — fallback / settlement evidence; deferred to ops (O-10), onboarded via config when available.
+- **Billing Ledger (`bss-ledger`)** — the sole consumer: `RateSyncJob` pulls `fetch_latest` and upserts each row under the per-rate provenance it carries (`ProviderRate.provider`, the serving source plugin's `id` — the composite's constant `provider_id()` never identifies the fetch source); `RateSource` and the FX stores consume the synced rates ([`../../ledger/docs/design/06-fx-multicurrency.md`](../../ledger/docs/design/06-fx-multicurrency.md)).
+
+### 3.6 Interactions & Sequences
+
+#### Sync tick → fetch → stamp
+
+- [ ] `p1` - **ID**: `cpt-cf-bss-rate-provider-seq-sync-tick-fetch`
+
+Once per tick the ledger `RateSyncJob` resolves its registered `RateProviderV1` (a scoped
+`ClientHub` lookup matched by vendor against the core gear's `PluginV1<RateProviderPluginSpecV1>`
+instance — the exact ledger-side call is out of this gear's boundary and not re-verified
+here), calls `fetch_latest(ctx, &[], request_id)` (whole table), and upserts each returned
+rate into `ledger_fx_rate` under the `provider` that rate carries. **Within this gear**,
+every such call re-runs `DiscoveringRateProvider`'s discovery of its own source plugins
+(§3.2) — nothing is cached between calls, so a plugin's registration, removal, or
+`priority` change takes effect on the very next tick with no gear restart. The cost is one
+types-registry list plus N in-memory `ClientHub` lookups per tick, on a job that ticks
+hourly by default and never runs on the posting path. The caller context is
+`SecurityContext::anonymous()` (system context) — no PEP gate on this internal cross-gear
+plugin call.
+
+#### Source fallback with provenance
+
+- [ ] `p1` - **ID**: `cpt-cf-bss-rate-provider-seq-source-fallback`
+
+Primary source fails (`Err` for the whole fetch) → the composite tries the next source in
+priority order → the first `Ok(document)` is returned **whole**, with every rate in it
+already stamped `provider = <that source's id>` → the ledger stores that id per row, so the
+synced rows record the true upstream regardless of how calls from other consumers interleave.
+
+#### All sources fail → ledger alarm
+
+- [ ] `p1` - **ID**: `cpt-cf-bss-rate-provider-seq-all-sources-fail`
+
+Every source returns `Err` → the composite returns the last `RateProviderError` → the
+ledger job raises `FX_SNAPSHOT_MISSING` (`billing.ledger.invariant.alarm`,
+`alarmCategory = fx-snapshot-missing`, Critical). The local store keeps its last synced
+rates; staleness marking and post blocking are the ledger's call.
+
+**The returned error is the LAST source's, so it is ordering-dependent and is not the
+diagnostic of record.** A single error value cannot name which source is the actual outage,
+and widening `RateProviderError` into an aggregate would push a per-source list through a
+ledger-owned SDK type that maps to one alarm anyway. The normative contract is therefore
+observability, not the error value:
+
+- Every failed source attempt **MUST** be logged at `warn` before the next source is tried,
+  carrying `source` (the attempted plugin's `id`), `request_id`, and the error.
+- The `request_id` is the tick's own, passed down unchanged from the ledger's `RateSyncJob`
+  through the composite to each source, so all attempts of one tick share it. Filtering the
+  gear's logs by that one id reconstructs the full attempt sequence in priority order —
+  including the sources whose errors the returned value discarded.
+- The ledger's `FX_SNAPSHOT_MISSING` alarm **MUST** carry that same `request_id` in its
+  detail, and so **MUST** the ledger's own failure log line. This is what makes the alarm the
+  entry point to the attempt sequence rather than a dead end: its `provider` field is the
+  *composite's* id, not the source that broke, and its error text is the last source's, so
+  without the id an operator holding the alarm has no key to filter the gear's logs by.
+- `fx_provider_fetch_errors_total{provider,kind}` stays the aggregate view; it counts
+  failures per source over time but cannot reconstruct a *specific* tick, which is what the
+  correlated log lines are for.
+
+### 3.7 Database schemas & tables
+
+**None.** The adapter is stateless — no tables, no migrations. The persisted FX state is
+owned by the ledger:
+
+- `ledger_fx_rate` — the local "latest known rates" store (`RateSyncJob` upsert target).
+- `rate_snapshot` — the immutable per-lock frozen rate.
+
+Both are defined in the ledger FX / Foundation designs
+([`../../ledger/docs/design/06-fx-multicurrency.md`](../../ledger/docs/design/06-fx-multicurrency.md),
+[`../../ledger/docs/design/01-repository-foundation.md`](../../ledger/docs/design/01-repository-foundation.md))
+and are NOT part of this gear.
+
+### 3.8 Deployment Topology
+
+Three stateless gear crates at `gears/bss/rate-provider/{rate-provider,plugins/ecb-plugin,
+plugins/http-json-plugin}` (placement per O-8; ECB's default `provider_id = "ecb"`),
+deployed in-process with the platform gear set — no standalone service, no DB. **Startup
+ordering (O-7, as implemented, superseding the original resolution below):** there is no
+`deps` edge between the core gear and its source plugins, and none is planned. The core
+gear's discovery is deferred to the first `fetch_latest` (the ledger's serve phase, after
+every gear's `init()` has run) and re-runs on every subsequent tick too (§3.2), so
+registration order among the three rate-provider gears never matters, and neither does a
+source plugin registering, deregistering, or changing `priority` after startup — the next
+tick picks it up, no restart needed.
+
+## 4. Additional context
+
+### Security & AuthZ
+
+- **Caller context:** the ledger calls `fetch_latest` with `SecurityContext::anonymous()`
+  (system context, not a per-request user). No PEP gate on this trait — it is an internal
+  cross-gear plugin call, not a tenant-scoped resource.
+- **No tenant data:** rates are global reference data; the adapter never sees tenant PII
+  and never writes tenant-scoped rows (the ledger does the RLS-scoped fan-out).
+- **Outbound TLS:** HTTPS via `toolkit-http` (hyper + rustls). ECB is public/unauthenticated;
+  paid providers need an API key (see constraint `cpt-cf-bss-rate-provider-constraint-secrets`).
+- **Outbound URL validation:** every `base_url` must have the `https` scheme **and** a host,
+  checked at that plugin's own `init()`
+  (`bss_rate_provider_sdk::http_client::build_source_http_client`) — fails loud on plain
+  `http`, on any other scheme, and on a hostless URL. The URL is *parsed* with the same
+  `http::Uri` type `toolkit-http` uses on the request path, not string-matched, so the gate
+  applies identical normalization: the scheme is compared case-insensitively (per RFC 3986
+  §3.1 `HTTPS://host` **is** https and is accepted — an earlier prefix check rejected that
+  working configuration), while `https://` with no authority is rejected (a prefix check
+  accepted it). **There is no loopback / private-network address check on `base_url`** —
+  that specific control is not implemented; a misconfigured `base_url` pointed at an internal
+  host is only caught by network reachability at fetch time, not rejected up front. (An
+  earlier draft of this document claimed such a check existed "unless explicitly allow-listed
+  for dev" — it does not, and there is no allow-list config either.)
+- **Redirect safety (this part IS implemented, inherited, not gear-specific code):** the
+  shared `toolkit-http` client's *default* `RedirectConfig` (`same_origin_only: true`,
+  `strip_sensitive_headers: true`, `allow_https_downgrade: false`) is what every source
+  plugin gets by not overriding it — cross-host redirects are refused unless allow-listed,
+  `Authorization`/`Cookie` are stripped on any redirect that does cross an origin, and an
+  HTTPS→HTTP downgrade is blocked. Config is operator-supplied (not tenant input), so this
+  is defense-in-depth against misconfiguration or a compromised/malicious upstream, not a
+  tenant-facing SSRF surface.
+- **Provider authenticity:** trusting the provider feed's authenticity is upstream/ops.
+
+### Feature metrics
+
+All metrics exposed as Prometheus scrape targets. (Provider **fallback** selection is
+measured ledger-side as `ledger_fx_provider_fallback_total{provider}`, emitted at lock time
+by `RateSource`; the adapter measures the fetch itself.)
+
+| Vector | Metric | Description | Target Threshold |
+|--------|--------|-------------|------------------|
+| **Efficiency** | `fx_provider_fetch_duration_seconds{provider}` | Outbound fetch+parse latency | p95 ≤ 2 s |
+| **Performance** | `fx_provider_rates_returned{provider}` | Pairs returned per successful fetch | — |
+| **Reliability** | `fx_provider_fetch_errors_total{provider,kind}` | Fetch failures by `RateProviderError` kind | — |
+| **Reliability** | `fx_provider_last_success_timestamp{provider}` | Publication time of the last successfully served document — the feed's own `as_of`, **not** the time we fetched it. A feed-freshness gauge, never a job-liveness one | — |
+| **Security** | `fx_provider_upstream_status_total{provider,status}` | Upstream HTTP status distribution | — |
+
+**Instrumentation ownership.** These are the **adapter's own** instruments (the fetch
+happens inside the source, out of the ledger's sight), so this gear MUST own a metrics
+handle — it does not piggy-back on the ledger's meter. Wire it at `init()` from the
+platform OTel meter; each source records under its own `provider_id` label. The
+`{provider}` label is the source `provider_id` (`"ecb"` / `"bank-x"`); for the composite,
+the source that actually served.
+
+**Liveness must be alerted on absence, not on errors.** Every metric above is emitted *by
+a fetch*. If the ledger's `RateSyncJob` stops ticking — scheduler wedged, task panicked and
+was not restarted, gear never reached `serve` — then no fetch happens, so
+`fx_provider_fetch_errors_total` never increments and any alert built on it stays silent
+while the rate store quietly goes stale. The provider-failure alarm cannot cover this case
+by construction.
+
+What *does* catch it is the pair of instruments a completed attempt always moves. Inside
+`fetch_and_parse` exactly one of them fires per attempt: a success records into
+`fx_provider_fetch_duration_seconds` (after the parse, so the `_count` series counts served
+documents), and any failure increments `fx_provider_fetch_errors_total`. That gives three
+distinguishable states:
+
+| State | `fetch_duration_seconds_count` | `fetch_errors_total` |
+|---|---|---|
+| Healthy | rising | flat |
+| Upstream outage | flat | **rising** |
+| **Nothing is attempting a fetch** | flat | flat |
+
+| Alert | Condition | Owner | Rationale |
+|-------|-----------|-------|-----------|
+| `FxNoFetchAttempted` | `rate(fx_provider_fetch_duration_seconds_count[3 × fx.rate_sync_tick_secs]) == 0 and rate(fx_provider_fetch_errors_total[3 × fx.rate_sync_tick_secs]) == 0 and rate(ledger_fx_rate_sync_ticks_total[3 × fx.rate_sync_tick_secs]) > 0`, held (`for:`) for at least one full sync pass — the adapter's 30 s per-source timeout ceiling × the configured source count | Platform on-call | "The job ticks but no attempt completes" — i.e. discovery yields no sources, which is what separates a dead feed from a slow one. The heartbeat term is part of the **condition**, not post-hoc correlation: without it a dead scheduler fires this alert for the wrong reason (that state belongs to `FxRateSyncStalled`), and because the ticker awaits the pass inline, the heartbeat stays flat while an attempt is still in flight — a slow pass suppresses this alert instead of firing it. The `for:` hold plus the 60 s floor on `fx.rate_sync_tick_secs` (ledger `FxConfig::validate`, window ≥ 180 s) close the remaining short-window false positive a sub-minute tick would otherwise allow. |
+| `FxFeedStale` | `time() - fx_provider_last_success_timestamp{provider} > <feed publication cadence>` | Platform on-call (feed freshness) | A **separate** concern from liveness — see the warning below. The threshold is set by how often the feed publishes, not by the sync tick: ECB publishes once per TARGET business day, so anything under ~72 h fires across every normal weekend. |
+
+**Job liveness is alerted in the ledger, not here.** `FxRateSyncStalled` and
+`FxRateSyncNeverRan` are defined over `ledger_fx_rate_sync_ticks_total` — the ledger's own
+scheduler heartbeat, incremented once per `RateSyncJob` tick before any provider is resolved.
+They live where the job lives: see the ledger's `design/06-fx-multicurrency.md`, the rate-source
+DoD in §8. This gear observes fetch **attempts**, one step downstream of the tick, so it is not
+in a position to define them.
+
+> **Do not build the liveness alert on `fx_provider_last_success_timestamp`.** That gauge is
+> deliberately set to the served **document's own publication time**, never wall-clock
+> (§"Testing architecture" pins this), so `time() - gauge` measures how old the *data* is,
+> not how long since we last ran. With ECB — whose `as_of` is a date at 00:00 UTC — a
+> perfectly healthy deployment already reads ~12 h at midday and ~66 h on a Sunday evening.
+> A `3 × fx.rate_sync_tick_secs` threshold on it would fire continuously. It answers a different
+> question, which is why it gets its own alert above.
+
+**This gear sees fetch attempts, not ticks — which is why the ledger heartbeat is a term in
+the alert's condition, not an after-the-fact correlation.** The
+core gear emits no instruments of its own, and `DiscoveringRateProvider::fetch_latest` fails at
+`discover()?` before reaching any source, so a discovery failure (a `vendor` typo, the
+types-registry being unavailable, no source plugin registered) leaves both counters here flat.
+On its own that is indistinguishable from a dead job; against the ledger's tick heartbeat it is
+not:
+
+| `ledger_fx_rate_sync_ticks_total` | `fx_provider_fetch_duration_seconds_count` | Diagnosis |
+|---|---|---|
+| flat | flat | The scheduler is dead — nothing is syncing (`FxRateSyncStalled`, ledger-side) |
+| **rising** | flat | The job is alive but discovery yields no sources (`FxNoFetchAttempted`) |
+
+The discovery half is then diagnosable from the error itself, which names the expected vendor
+and the ones actually present in the registry (§3.2).
+
+Both alerts are ledger-deployment concerns (the job lives there); the ones above are listed
+here because the instruments they read are this gear's.
+
+**Acceptance test.** With a configured provider, stop the `RateSyncJob` and assert that
+`fx_provider_fetch_duration_seconds_count` and `fx_provider_fetch_errors_total` both stay
+flat — i.e. that the stall is invisible to error-based alerting. Assert separately that
+`fx_provider_last_success_timestamp` alone would NOT have caught it, since it can read
+arbitrarily stale on a healthy feed between publications. That the *tick* stopped is asserted
+ledger-side on `ledger_fx_rate_sync_ticks_total` (ledger `design/06-fx-multicurrency.md` §8).
+
+### Testing architecture
+
+**Correction vs. the original draft below:** there is no `FakeHttpTransport` mock-transport
+abstraction anywhere in the implementation. Unit tests call the pure parsing/mapping/
+conversion functions directly with byte/JSON fixtures (no HTTP layer involved at all);
+HTTP-layer behavior is covered by integration tests against a *real* in-process `axum`
+server over loopback, not a fake transport trait. There is also a whole test category the
+original draft didn't anticipate — discovery/vendor-filtering/priority-ordering/caching —
+covered by a `ClientHub` + mock-registry integration test, not a unit test, since it
+exercises real cross-gear wiring.
+
+| Level | Database | Network | What is real | What is mocked |
+|---|---|---|---|---|
+| **Unit** | None | None | Parser (`parse_ecb_xml`), field mapping (`map_json_document`/`json_lookup`), `rate_micro` conversion, HTTP-error mapping, `provider_id` | Nothing — pure functions called directly with fixture bytes/JSON, no transport abstraction |
+| **Component integration** (`tests/discovery.rs`) | None | None | A real `ClientHub` + `DiscoveringRateProvider`; fake `RateProviderV1` sources registered scoped | `TypesRegistryClient` — `types-registry-sdk::testing::MockTypesRegistryClient`, a real test-util the SDK ships |
+| **HTTP integration** (`tests/ecb_integration.rs`, `tests/http_json_integration.rs`) | None | Real in-process `axum` server over loopback | `EcbRateProvider` / `HttpJsonRateProvider` end-to-end, incl. auth headers, timeouts, connection failure | The real external ECB / bank endpoint |
+| **API** | N/A | In-process | Trait-level: `fetch_latest`/`health` contract behavior | — (no REST surface) |
+| **E2E** | Real (ledger) | Real HTTPS | Adapter registered in ClientHub; ledger `RateSyncJob` populates `ledger_fx_rate`; an EUR-invoice-under-USD post locks a rate | Optionally the live ECB feed (gated) |
+
+**Unit tests** (`*_tests.rs` files next to the code under test, per this repo's
+`de1101_tests_in_separate_files` convention):
+
+| What to test | Verification target |
+|---|---|
+| Parse ECB daily XML fixture → `(NaiveDate, Vec<(String, String)>)` | All EUR pairs decoded; `as_of` = publication date UTC; a duplicate currency is logged and the first occurrence wins; a second **distinct** date fails the document with an error naming both dates, while a repeat of the same date still parses |
+| `rate_micro` conversion determinism | `round(rate×1e6)` half-to-even (`rust_decimal`) over exact decimal parsing (no `f64` path); half-way golden vectors incl. negative; exact `i64::MAX`/`i64::MIN` boundary and one-past-boundary overflow |
+| Requested pair not published / case-insensitive pair match / inverse leg (X→EUR) requested | Omitted from result (not an error); a lowercase-cased request still matches (both sources); the inverse leg is never synthesized |
+| Upstream 5xx / network failure / malformed payload | `UpstreamStatus` / `Unreachable` / `Internal` respectively, via `map_http_error` |
+| `InvalidUri` mapping never echoes the raw URL | `Internal` message contains the structured `kind` + `reason`, never the URL (which may carry a spliced-in secret) |
+| `provider_id` | Returns configured id |
+| **Future-publication-time bound** (`publication_time_tests.rs`, plus one HTTP-integration test per source) | Exactly `MAX_FUTURE_SKEW_HOURS` ahead still serves and one second past it is rejected — the pair pins the bound, where either alone would pass for an arbitrary window; a full day ahead serves (the date-only-feed case); an arbitrarily old `as_of` is NOT rejected here (age is the ledger's rule); end-to-end, a future-dated document fails the fetch with an error naming the offending timestamp |
+| **Per-rate provenance** (both sources) | Every returned rate carries `provider = <the serving source's id>`, so the ledger stores the true upstream per row |
+| **ISO-4217 currency gate** (both sources) | A non-three-ASCII-letter `quote` from the feed is dropped/skipped and logged; a lowercase code is normalized to uppercase; a malformed configured `mapping.base` fails the whole http-json document; an all-malformed ECB feed surfaces the empty-table `Internal` error |
+| **Per-entry resilience to a bad rate** (both sources) | One unconvertible (non-numeric, zero, negative, overflowing) rate is skipped and logged while the rest of the document still serves; a half-populated ECB `Cube` is ignored and logged; only an all-entries-failed batch is an `Internal` error, whereas an empty result caused purely by a non-empty requested-`pairs` filter is `PairUnavailable` (never `Ok`) |
+| **ISO-4217 helper** (`currency.rs`) | Accepts three-letter codes case-insensitively; rejects wrong length, non-alphabetic, injection-shaped, and multibyte-but-3-byte input |
+| Zero-mappable `http-json` document (empty `rates` object, or every entry individually fails to map) | `RateProviderError::Internal` in both cases, never `Ok([])` — the composite fallback must trigger |
+| **`http-json` `as_of` / `rates` path error branches** | Missing `as_of`, non-RFC3339 `as_of`, non-string `as_of`, missing `rates`, `rates` not an object — each an `Internal` error (a regression defaulting `as_of` to `now()` would otherwise mis-timestamp silently) |
+| Generic `http-json` mapping → `Vec<ProviderRate>` | `mapping` resolves base/quote/rate/as_of; string AND numeric rate values accepted; an unmappable entry is skipped (logged with its quote + reason), never fabricated |
+| **`http-json` auth config shape** | `bearer`/`header-key` carry their key; a kind that needs a key without one, a key attached to `none`, an unknown kind, and a stray top-level `api_key` are each rejected at config load |
+| Composite fallback order + provenance; all-sources-fail; **health fallback**; **empty source list** | Secondary document returned whole on primary failure with its own provenance; **distinct** per-source errors prove the LAST error propagates (fetch AND health); health short-circuits on the first healthy source; `provider_id()` returns the configured id and `fetch_latest`/`health` error (never panic) when the list is empty |
+| **`fetch_and_parse` metrics contract** (`fetch_tests.rs`, recording `FetchMetrics` fake over a real local server) | Success records status + duration + count + `set_last_success(<document's as_of>)`, never wall-clock; a non-2xx records `kind="upstream_status"` and NO success; a parse failure's label comes from the returned error (`invalid_pair`, `internal`), not a hardcoded kind; a transport failure records `kind="unreachable"` and no status |
+| **`build_source_http_client`** | `https://` builds, and so does any casing of the scheme (`HTTPS://`, `HttPs://`) since a URI scheme is case-insensitive; plain `http` (either casing), other schemes, a scheme-less URL, and an `https` URL with no host are all rejected; a zero `timeout_ms` is rejected while 1 ms builds, and exactly `MAX_TIMEOUT_MS` builds while one millisecond past it is rejected (the pair pins the ceiling, where either alone would pass for an arbitrary bound); no rejection error — scheme, parse failure, or oversized timeout — echoes the URL or its embedded credential, and the oversized-timeout message names the ceiling |
+| **OTel metric instruments** (`metrics_tests.rs`, in-memory exporter) | All five documented Prometheus names are exported; every instrument carries `provider`; errors carry `kind`; statuses carry `status`; recorded counter/gauge values reach the exporter unchanged |
+| Each gear's built instance id parses as a valid GTS id | `assert_registration_builds_valid_gts_id` (shared helper, one `#[test]` per gear) |
+
+The http-json plugin's `mapping`-required check in `init()` is pinned by a dedicated test
+(`gear.rs`, driving the real `init()` over a static config provider): a present,
+otherwise-valid config without `mapping` aborts init with an error naming the field, so a
+feed that could map no document never registers. The auth half of that validation is
+covered at the config-parse level instead, since it became a serde error rather than a
+runtime check.
+
+**Component-integration tests** (`tests/discovery.rs`; real `ClientHub`, no network, no DB):
+
+| What to test | Verification target |
+|---|---|
+| Composes in priority order, stamps the serving source | Lower `priority` served first; the returned rate carries its id; `provider_id()` stays the composite's constant identity |
+| Falls back to the next priority on failure | Fallback source serves; the rate's `provider` reflects it |
+| Filters out a different-vendor source, even at a lower priority | Vendor mismatch excludes it regardless of priority |
+| No matching-vendor source registered | `fetch_latest` errors |
+| **Instance published without a scoped client** | That source is excluded, not fatal — a healthy sibling still serves |
+| **A failed tick self-heals** | First tick fails (instance published, client not yet registered); after the client registers, the next tick succeeds and re-queried the registry — no cached failure |
+| Discovery re-runs every tick, not just the first | A second `fetch_latest` re-lists instances (no cross-tick cache) so a `priority`/registration change takes effect without a restart |
+| Concurrent fetches each discover independently | Two concurrent callers each run their own discovery pass — nothing to dedupe against once there is no shared cache |
+| **`health()` over discovered sources** | Probes the discovered chain and falls through a failing source to a healthy one |
+
+**HTTP-integration tests** (`tests/ecb_integration.rs`, `tests/http_json_integration.rs`; a
+real in-process `axum` server, no DB):
+
+| What to test | Setup | Verification target |
+|---|---|---|
+| Full fetch over local server | Serve the ECB XML fixture / a JSON feed body | `fetch_latest(&[])` returns the full table/document |
+| Whole-table vs specific pairs, incl. out-of-base omission | Serve full feed | A requested pair returns only that pair; an unpublished/wrong-base pair is omitted, never synthesized |
+| `health` probe (HEAD), both sources | Serve 200; serve 403 / 404 / 405 / 500 / 503; a `GET`-only route (so HEAD gets axum's 405); no listener at all | Every HTTP status is `Ok(())` — the host answered — and only the transport failure is `Unreachable`. The pair pins the rule: either case alone would pass for a probe that always succeeded, or always failed on a non-2xx. The `GET`-only case is the one that makes a HEAD probe viable for an arbitrary configured feed |
+| Auth headers (`bearer` / `header-key`) | Server 401s unless the exact header is present | Correct header sent; `none` sends no credential and the authenticated feed rejects it (401); a wrong key surfaces `UpstreamStatus(401)` rather than looking successful. A *keyless* `bearer` is not an HTTP case at all — `Auth::Bearer` requires its `api_key`, so the shape is unrepresentable and is covered as a config-load rejection in `config_tests.rs` |
+| Upstream 5xx / connection refused | Serve 503 / drop the listener after binding | `UpstreamStatus(503)` / `Unreachable` |
+
+The slow-but-reachable upstream is pinned at the `fetch_and_parse` level (`fetch_tests.rs`,
+shared by both plugins): a live local server that answers only after the configured timeout
+maps to `Unreachable`, records the error metric, and moves no success instrument and no
+upstream-status count — the case connection refusal cannot represent, since there the
+transport fails instantly instead of being cut off by `timeout_ms`.
+
+**API tests:** no REST surface — the "contract" tests are the trait-level behaviors covered
+at Unit/Integration. If a debug endpoint is ever added (O-6), add RFC 9457 error tests then.
+
+**E2E tests** (planned location: `testing/e2e/modules/bss-ledger/`, extends the FX suite):
+
+| What to test | Marker | Verification target |
+|---|---|---|
+| Adapter registered → ledger sync populates store | `@pytest.mark.smoke` | After a `RateSyncJob` tick, a cross-currency post locks a rate (no `FX_RATE_UNAVAILABLE`); the posted line's `rate_snapshot_ref` is then readable via the item endpoint `GET /fx/rate-snapshots/{rateId}` (there is no collection `GET`) |
+| Provider unreachable → post blocks | — | With the adapter down, an EUR-under-USD post returns `FX_RATE_UNAVAILABLE` (fail-safe), and `fx-snapshot-missing` alarm fires |
+| Live ECB fetch (gated) | `@pytest.mark.external` | A real ECB fetch returns a non-empty EUR table |
+
+**What must NOT be mocked:**
+
+| Component | Why |
+|---|---|
+| `rate_micro` conversion | Money precision — must be exact and deterministic against real parsing |
+| The `RateProviderV1` contract behavior (`&[]` semantics, omit-on-unavailable) | The ledger job relies on it verbatim |
+| Ledger fail-safe (block on empty store) — E2E | Proves "block, not guess" end to end |
+
+**NFR verification mapping:**
+
+| NFR | Test level | How verified |
+|---|---|---|
+| Post-path isolation | E2E | Provider down → posts still fast; only FX posts block |
+| Fetch latency p95 ≤ 2 s | Integration + load | Timed fetch against local server; sample live ECB |
+| Deterministic conversion | Unit | Golden-vector tests over the conversion function |
+| Feed freshness | E2E | Sync tick populates store within the tick window |
+
+### Decision register
+
+| Ref | Item | Resolution | Owner |
+|-----|------|------------|-------|
+| **O-1** | Multiple providers vs single `dyn RateProviderV1` | ✅ **DECIDED — composite adapter, no merge.** ONE composite registered; ordered sources; first whole document; provenance stamped per rate (§3.1/§3.2 — the last-served-index scheme this originally specified was replaced, see O-7a). Variant (b) — a ledger-side scoped multi-provider loop — stays a future option if per-pair fallback is ever needed. **REVISED 2026-07-23 (plugin rework): each source is a scoped `PluginV1` and the composite is itself a discovered plugin — see the Implementation-revision note at the top.** | Architecture |
+| **O-2** | ECB source & format | ✅ **Accepted (2026-07-08):** direct ECB daily XML for prod; Frankfurter allowed for dev; SDMX optional. **As implemented:** XML-only — no `format` config field, no Frankfurter/SDMX code path shipped. Add if a non-XML feed is ever actually needed. | PM + Architecture |
+| **O-3** | Triangulation ownership | ✅ **DECIDED (2026-07-08) — the ledger owns triangulation.** The adapter emits only native direct pairs; cross-base rates are computed ledger-side in `RateSource`. Companion ledger change required (below). | Architecture |
+| **O-4** | Conversion rounding mode | ✅ **Accepted (2026-07-08):** banker's rounding (half-to-even) — inherited from the ledger's platform default (`cpt-cf-bss-ledger-fr-money-rounding-scale`, `p1`), not selected here. Not a release gate for this gear: deviating would break that requirement rather than differ from it, so a revision can only come from the ledger changing its default. | Ledger (owner) · PM + Finance (informed) |
+| **O-5** | `rate_micro` precision sufficiency | ✅ **Accepted (2026-07-08):** keep ×1e6 (6 dp) for v1; revisit for high-unit / crypto pairs (any change is an SDK change). | Architecture |
+| **O-6** | Debug/observability endpoint | ✅ **Accepted (2026-07-08):** metrics only for v1 — no debug HTTP endpoint; ops rely on metrics + the trait `health`. | Team |
+| **O-7** | Gear vs plugin & startup order | ✅ **Accepted (2026-07-08):** rely on the fail-safe + next tick; verify startup ordering during implementation (add a ledger `deps` edge if ordering proves unreliable). **REVISED 2026-07-23 (plugin rework): no `deps` edge — the ledger discovers the composite lazily each rate-sync tick, so a late adapter self-heals.** | Architecture |
+| **O-7a** | Composite provenance coupling (from O-1) | ✅ **RESOLVED (superseding the earlier "accepted for v1").** The original design had `provider_id()` report the last-served source, which held only while a single non-concurrent ticker called `fetch_latest` before `provider_id` in one pass — any second `ClientHub` consumer fetching in between made the ledger stamp the wrong source onto `ledger_fx_rate`/`rate_snapshot`. Taken instead: the option the entry itself named — `ProviderRate` now carries its own `provider`, each source stamps it, and `provider_id()` is a constant adapter identity. No call-order assumption remains. | Architecture |
+| **O-8** | Crate placement & naming | ✅ **Accepted (2026-07-08):** `gears/bss/rate-provider`, `provider_id = "ecb"` (confirm against gear conventions at implementation). | Team |
+| **O-9** | Jira / slice linkage | ✅ **Accepted (2026-07-08):** create a Technical task under the Slice-5 FX epic (VHP-1853 / VHP-1986 family), linked to the O-3 companion ledger ticket — action pending. | PM |
+| **O-10** | Bank / PSP fallback source | ✅ **Accepted (2026-07-08):** v1 = ECB-only; bank/PSP added later as a `sources[]` entry (generic `http-json` if a plain REST feed, else a dedicated `kind` for signed/settlement auth). **As implemented (plugin rework):** added later as one more deployed plugin gear configured with a matching `vendor` (the existing `bss-rate-provider-http-json-plugin` if a plain REST feed, else a new plugin crate for signed/settlement auth). Concrete feed + credentials deferred to ops. | PM + Ops |
+| **O-11** | Generic `http-json` mapping grammar | ✅ **Accepted (2026-07-08):** v1 = single-base JSON feeds, simple field paths, `none` / `bearer` / `header-key` auth; richer transforms deferred. | Architecture |
+| **O-12** | `init()` config-validation strictness | ✅ **DECIDED (2026-07-17):** fail `init()` loud on an unknown `kind`, an empty `sources[]`, or a `sources[]` order that does not match the ledger `fx.provider_order` — a mismatch would let the composite fetch one provider while the ledger's precedence resolution prefers another's stored rate. **REVISED 2026-07-23 (plugin rework): no `sources[]` — source assembly is plugin discovery ordered by each plugin's `priority`; cross-gear alignment is a matching `vendor` (core gear ↔ source plugins ↔ ledger `fx.provider_vendor`).** | Architecture |
+| **O-13** | Is coverage a success criterion for a served document? (raised in review of the parsing rules vs the "first whole document" / "all-or-nothing per source" phrasing) | ✅ **DECIDED — no. Per-entry skip is the normative semantic; "all-or-nothing" is about provenance only.** A document with some entries skipped, or with fewer pairs than the ledger would like, is a **success** and does NOT trigger fallback. Neither candidate gate was taken: "all requested pairs" is vacuous on the real call path (`RateSyncJob` fetches with empty `pairs`) and incompatible with ECB's EUR-only publication; "a minimum expected set" is an operator-maintained duplicate of each feed's contents that goes stale on the first upstream listing change. Both also invert the intended failure mode — any provider error becomes `FX_SNAPSHOT_MISSING` and refreshes nothing, so one bad entry would stale every pair instead of one. A pair that stops being refreshed is surfaced by the layer that owns the age policy: the ledger's staleness window → `FX_RATE_UNAVAILABLE` (block, never a wrong rate). Per-pair fallback stays deferred (O-1 variant (b)). See §2.1 "One source per document — provenance, not coverage". | Architecture |
+
+### Companion ledger change (hard dependency, from O-3)
+
+O-3 puts triangulation in the ledger, so this gear ships **direct pairs only**. Enabling
+the ledger's deferred triangulation is therefore a **hard dependency**, tracked as a
+separate `bss-ledger` work item — NOT part of this gear:
+
+- **Where:** `bss-ledger` `infra/fx/rate_source.rs` — today `resolve()` reads direct pairs
+  only (a documented TODO); it MUST compute `X → EUR → Y` (via the configured bridge
+  currency) when no direct pair exists. This **includes deriving the `X → EUR` leg by
+  deterministically inverting** the stored `EUR → X` rate — the adapter emits only ECB's
+  native EUR-based pairs, so without ledger-side inversion no non-EUR-base pair (e.g.
+  `USD→EUR`) can resolve at all.
+- **Snapshot:** the resulting `rate_snapshot` MUST record `triangulated_via` (the bridge
+  currency) — the column already exists on `ledger_fx_rate_snapshot`.
+- **Determinism:** the bridge path + rounding MUST be deterministic and
+  auditor-reproducible (banker's rounding per O-4).
+- **Sequencing:** this adapter can ship first — EUR-functional / EUR-base tenants already
+  work with direct pairs. Non-EUR-functional tenants are unblocked only once the ledger
+  triangulation lands. Track the two as linked tickets (O-9).
+
+## 5. Traceability
+
+- **PRD (this gear)**: [`PRD.md`](./PRD.md) — the adapter's own product requirements
+  (`cpt-cf-bss-rate-provider-fr-*` / `-nfr-*`), derived from the ledger PRD below.
+- **Upstream PRD**: [`../../ledger/docs/PRD.md`](../../ledger/docs/PRD.md) — § Multi-currency and
+  foreign exchange, § FX rate-source failure and staleness
+  (`cpt-cf-bss-ledger-fr-multi-currency-fx`, `cpt-cf-bss-ledger-fr-fx-rate-source-failure`).
+- **Consuming design**:
+  [`../../ledger/docs/design/06-fx-multicurrency.md`](../../ledger/docs/design/06-fx-multicurrency.md)
+  (the ledger side: `RateSource`, staleness, snapshots, the rate-source-fallback
+  algorithm, and the frozen rate-snapshot state) and
+  [`../../ledger/docs/design/01-repository-foundation.md`](../../ledger/docs/design/01-repository-foundation.md)
+  (functional columns, currency-scale registry).
+- **Code seam (existing)**: `bss-ledger-sdk` `rate_provider.rs` (`RateProviderV1` trait);
+  `bss-ledger` `infra/jobs/rate_sync.rs`, `infra/fx/rate_source.rs`, `config.rs`
+  (`FxConfig`), `module.rs` (ClientHub resolution).
+- **Provenance**: authored from the architecture-repo draft
+  `DESIGN-billing-fx-module-202607011613` (vhp-architecture, `docs/bss/design/`), which
+  itself traces to `PRD-billing-ledger-balances-202604041200`,
+  `DESIGN-billing-ledger-balances-202606091200` (slices 01 / 06), and
+  `ADR-platform-persistence-layer-202601221200`.

--- a/gears/bss/rate-provider/docs/PRD.md
+++ b/gears/bss/rate-provider/docs/PRD.md
@@ -1,0 +1,591 @@
+<!-- CONFLUENCE_TITLE: [BSS]: FX Rate Provider (Adapter Gear) — Product Requirements -->
+<!-- Related: ./DESIGN.md, ../../ledger/docs/PRD.md, ../../ledger/docs/design/06-fx-multicurrency.md | Owners: @vstudzinskyi (BSS Billing Platform team) -->
+
+# PRD — FX Rate Provider (Adapter Gear)
+
+<!-- toc -->
+
+- [1. Overview](#1-overview)
+  - [1.1 Purpose](#11-purpose)
+  - [1.2 Background / Problem Statement](#12-background--problem-statement)
+  - [1.3 Goals (Business Outcomes)](#13-goals-business-outcomes)
+  - [1.4 Glossary](#14-glossary)
+- [2. Actors](#2-actors)
+  - [2.1 Human Actors](#21-human-actors)
+  - [2.2 System Actors](#22-system-actors)
+- [3. Operational Concept & Environment](#3-operational-concept--environment)
+  - [3.1 Gear-Specific Environment Constraints](#31-gear-specific-environment-constraints)
+- [4. Scope](#4-scope)
+  - [4.1 In Scope](#41-in-scope)
+  - [4.2 Out of Scope](#42-out-of-scope)
+- [5. Functional Requirements](#5-functional-requirements)
+  - [5.1 Rate Feed](#51-rate-feed)
+  - [5.2 Sources & Fallback](#52-sources--fallback)
+- [6. Non-Functional Requirements](#6-non-functional-requirements)
+  - [6.1 Gear-Specific NFRs](#61-gear-specific-nfrs)
+  - [6.2 NFR Exclusions](#62-nfr-exclusions)
+- [7. Public Library Interfaces](#7-public-library-interfaces)
+  - [7.1 Public API Surface](#71-public-api-surface)
+  - [7.2 External Integration Contracts](#72-external-integration-contracts)
+- [8. Use Cases](#8-use-cases)
+  - [Fallback serve with provenance](#fallback-serve-with-provenance)
+  - [Onboard a new REST feed by configuration](#onboard-a-new-rest-feed-by-configuration)
+- [9. Acceptance Criteria](#9-acceptance-criteria)
+- [10. Dependencies](#10-dependencies)
+- [11. Assumptions](#11-assumptions)
+- [12. Risks](#12-risks)
+- [13. Open Questions](#13-open-questions)
+- [14. Traceability](#14-traceability)
+
+<!-- /toc -->
+
+> **Implementation revision (2026-07-23) — `*-plugin` pattern.** The requirements
+> below are unchanged, but the gear was built on the platform's plugin pattern:
+> each rate source (ECB, http-json) is a **source plugin** that self-registers in
+> the types-registry, a **core gear** discovers + composes them (ordered by each
+> plugin's `priority`), and the ledger discovers the composite **lazily each sync
+> tick**. So "config-driven source assembly / ordered fallback" (FR
+> `cpt-cf-bss-rate-provider-fr-config-onboarding` / `-ordered-source-fallback`) is
+> realized by plugin discovery + `priority`, and "strict config validation" (FR
+> `cpt-cf-bss-rate-provider-fr-strict-config-validation`) is per-plugin (an
+> http-json plugin requires a `mapping` + https `base_url`) with cross-gear
+> alignment by a shared `vendor`. See `DESIGN.md` § Implementation revision.
+>
+> **Review revision (2026-07-28).** Two requirement-level clarifications came out
+> of code review, both narrowing how a requirement is met rather than what it is:
+> true-source provenance (`-fr-source-provenance`) is carried **per rate** instead
+> of via a separate "who served last" call, which removes a concurrency hazard on
+> audit data; and the http-json plugin's authentication config is now shaped so
+> unusable credential combinations cannot be expressed at all (a config-load
+> error), instead of being caught by a startup check
+> (`-fr-strict-config-validation`). Feed-supplied currency codes are also gated on
+> the ISO-4217 shape before reaching any tenant store.
+
+## 1. Overview
+
+### 1.1 Purpose
+
+The **FX rate-provider gear** supplies the Billing Ledger with **live foreign-exchange
+reference rates**. It is a stateless fetch-only adapter: it retrieves the latest published
+rates from configured external sources (ECB primary; further feeds by configuration) and
+hands them to the ledger through the ledger-owned `RateProviderV1` contract. It stores
+nothing, exposes no REST surface, and performs no accounting.
+
+### 1.2 Background / Problem Statement
+
+The ledger's multi-currency posting (ledger PRD § Money, Rounding & Foreign Exchange)
+requires a live rate feed to translate transaction currency into functional currency, but
+the ledger deliberately declares the provider integration out of its own scope — it ships
+only the consuming seam (`RateProviderV1`, `RateSyncJob`, the local rate store, and the
+fail-safe that blocks FX posts when no rate is available). Until an adapter implements
+that seam, every FX post blocks (`FX_RATE_UNAVAILABLE`). This gear closes that gap.
+
+### 1.3 Goals (Business Outcomes)
+
+- **Unblock multi-currency billing**: with the adapter deployed and one source configured,
+  cross-currency invoice posting works without manual rate seeding, for the pairs a
+  configured source publishes directly. ECB publishes EUR-based pairs, so this covers
+  EUR-functional tenants; non-EUR functional currencies additionally need the ledger-side
+  triangulation/inversion change tracked as a hard companion dependency (DESIGN §4).
+- **Auditable rates**: every synced rate is traceable to a named provider and its original
+  publication timestamp — no fabricated or silently stale values.
+- **Cheap provider onboarding**: a new plain REST rate feed is added by configuration
+  only, with no code change and no redeployment of consuming modules.
+
+### 1.4 Glossary
+
+| Term | Definition |
+|------|------------|
+| Reference rate | An FX rate published by an institution (e.g. ECB) for a currency pair on a given date. |
+| Functional currency | The tenant's accounting currency the ledger translates into. |
+| Direct pair | A pair the provider itself publishes (ECB publishes EUR→X only). |
+| Rate document | The whole set of pairs one source returns for one fetch. |
+| Provenance | Which concrete source actually served the rates recorded by the ledger. |
+| Fail-safe by absence | On provider failure the ledger blocks FX posts rather than guessing a rate. |
+
+## 2. Actors
+
+### 2.1 Human Actors
+
+#### Platform Operator
+
+**ID**: `cpt-cf-bss-rate-provider-actor-platform-operator`
+
+- **Role**: Configures rate sources (order, endpoints, credentials) and operates the
+  platform deployment; reacts to feed-freshness alarms raised by the ledger.
+- **Needs**: Config-only source management, clear startup validation errors, fetch metrics.
+
+#### Finance Controller / Auditor
+
+**ID**: `cpt-cf-bss-rate-provider-actor-finance-auditor`
+
+- **Role**: Signs off FX treatment; audits which rate was applied to which posting.
+- **Needs**: Deterministic rate conversion and per-rate provider/publication-time provenance.
+
+### 2.2 System Actors
+
+#### Billing Ledger (`RateSyncJob`)
+
+**ID**: `cpt-cf-bss-rate-provider-actor-ledger-rate-sync`
+
+- **Role**: Sole consumer. Periodically pulls the latest rate document through
+  `RateProviderV1` and upserts it into the ledger's local rate store.
+
+#### ECB Reference-Rate Feed
+
+**ID**: `cpt-cf-bss-rate-provider-actor-ecb-feed`
+
+- **Role**: Primary external source — free, EUR-based daily reference rates.
+
+#### Bank / PSP Rate Feed (future)
+
+**ID**: `cpt-cf-bss-rate-provider-actor-bank-psp-feed`
+
+- **Role**: Fallback / settlement-evidence source, onboarded by configuration when
+  procured by ops (DESIGN decision O-10).
+
+## 3. Operational Concept & Environment
+
+Runtime, OS, and lifecycle policy follow the repository-level platform defaults
+([`guidelines/`](../../../../guidelines/)); the consuming seam is defined by the parent
+[ledger PRD](../../ledger/docs/PRD.md).
+
+### 3.1 Gear-Specific Environment Constraints
+
+- Requires **outbound HTTPS egress** to configured provider endpoints (unusual for gears —
+  most have no external egress).
+- No database and no per-tenant state: rates are global reference data; the ledger owns
+  all persistence and the per-tenant fan-out.
+
+## 4. Scope
+
+### 4.1 In Scope
+
+- Fetching the latest published rate document from configured external sources.
+- Ordered cross-source fallback at fetch time with true-source provenance.
+- Implementing the ledger's `RateProviderV1` contract (fetch, health, provider identity).
+- Config-driven source assembly, including no-code onboarding of plain REST JSON feeds.
+- Deterministic conversion of published decimal rates into the contract's fixed-precision
+  integer representation.
+
+### 4.2 Out of Scope
+
+- Rate persistence, staleness marking, snapshotting, per-tenant fan-out — ledger-owned.
+- Currency translation, triangulation / pair inversion — ledger-owned (DESIGN O-3).
+- Pricing-side FX and rate-lock governance — Catalog module.
+- Provider commercial contracts and credential procurement — ops.
+- Manual / break-glass rate ingest — the ledger's own seed endpoint.
+
+## 5. Functional Requirements
+
+### 5.1 Rate Feed
+
+#### Live rate feed via the ledger contract
+
+- [ ] `p1` - **ID**: `cpt-cf-bss-rate-provider-fr-live-rate-feed`
+
+The gear **MUST** supply the latest published FX rates to the Billing Ledger through the
+ledger-owned `RateProviderV1` contract, returning the whole published table when no
+specific pairs are requested.
+
+- **Rationale**: The ledger requirement `cpt-cf-bss-ledger-fr-multi-currency-fx`
+  (ledger PRD § Multi-currency & FX) needs a live feed; this gear is that feed.
+- **Actors**: `cpt-cf-bss-rate-provider-actor-ledger-rate-sync`
+
+#### Provider publication time
+
+- [ ] `p1` - **ID**: `cpt-cf-bss-rate-provider-fr-provider-publication-time`
+
+Every returned rate **MUST** carry the provider's original publication timestamp (UTC) —
+never the fetch time. On non-publication days the last published rate is returned with its
+original timestamp unchanged.
+
+A publication timestamp more than **26 hours ahead** of the gear's own clock **MUST** be
+rejected: the whole document fails with an error, so the composite falls through to the next
+source and nothing is stored. Validation is the **source plugin's**, performed at parse time
+before any rate is built. Timestamps in the *past* are never rejected here — age is the
+ledger's staleness policy, and duplicating it in the adapter would put the same rule in two
+layers.
+
+- **Rationale**: The ledger's staleness policy
+  (`cpt-cf-bss-ledger-fr-fx-rate-source-failure`) is only meaningful against true
+  publication time; stamping fetch time would mask stale feeds. That policy measures *age*,
+  which only bounds the past: a future-dated document has a negative age and therefore reads
+  as permanently fresh, so a feed publishing a timestamp a month out would keep the ledger
+  posting at a frozen rate with no staleness alarm ever firing. The ledger cannot catch this
+  itself — by then the value is just a stored row, indistinguishable from "we have not synced
+  recently"; only the plugin knows it came straight off the wire this tick. The 26 h bound is
+  14 h (the widest civil timezone offset, so a date-only feed anchored at 00:00 UTC is never
+  rejected) plus 12 h of host clock drift.
+- **Actors**: `cpt-cf-bss-rate-provider-actor-finance-auditor`
+
+#### Direct pairs only
+
+- [ ] `p1` - **ID**: `cpt-cf-bss-rate-provider-fr-direct-pairs-only`
+
+The gear **MUST** emit only pairs the serving source natively publishes. A pair the source
+cannot serve is omitted — never synthesized, inverted, or merged from another source.
+Cross-base derivation is the ledger's triangulation concern.
+
+- **Rationale**: Keeps every synced document single-source-coherent for audit and keeps
+  rate-math ownership in one place (DESIGN O-1 / O-3).
+- **Actors**: `cpt-cf-bss-rate-provider-actor-finance-auditor`
+
+### 5.2 Sources & Fallback
+
+#### Ordered source fallback
+
+- [ ] `p1` - **ID**: `cpt-cf-bss-rate-provider-fr-ordered-source-fallback`
+
+The gear **MUST** try configured sources in their configured order and return the first
+whole successful rate document. Only when **all** sources fail may it report failure to
+the caller.
+
+"Whole" is a **provenance** rule — the document served comes from one source, entire, never
+stitched together across sources. It is **not** a coverage rule: a source that publishes
+fewer pairs than the ledger would like, or whose document had individual invalid entries
+skipped during parse, has **succeeded**, and the gear **MUST NOT** fall through to the next
+source on that basis. Fallback is triggered only by a source-level failure (transport,
+upstream status, whole-document parse failure, or a document from which nothing usable
+survives). Per-pair fallback is out of scope for v1 — see DESIGN O-13.
+
+- **Rationale**: Realizes the fallback algorithm the ledger design expects at fetch
+  time ([ledger FX design § rate-source fallback](../../ledger/docs/design/06-fx-multicurrency.md)),
+  where the ledger cannot do it itself. Coverage is not gated here because any provider error
+  makes the ledger's `RateSyncJob` refresh **nothing**, so gating on completeness would trade
+  a few stale pairs for all of them; a pair that stops being refreshed is instead surfaced by
+  the ledger's own staleness window (`FX_RATE_UNAVAILABLE`).
+- **Actors**: `cpt-cf-bss-rate-provider-actor-ledger-rate-sync`
+
+#### True-source provenance
+
+- [ ] `p1` - **ID**: `cpt-cf-bss-rate-provider-fr-source-provenance`
+
+The gear **MUST** report the identity of the source that actually served each rate, so
+ledger rate rows and snapshots record the true upstream — never a generic adapter name.
+
+- **Rationale**: Auditors must be able to answer "whose rate was applied here".
+- **Actors**: `cpt-cf-bss-rate-provider-actor-finance-auditor`
+- **As implemented:** provenance is carried **per rate** (a `provider` field on each returned
+  rate), not reported through a separate "who served last" call. The latter was only correct
+  while a single caller strictly alternated fetch → ask-who-served; the adapter is registered
+  process-wide, so a second consumer fetching in between would have made the ledger stamp
+  the wrong source onto financial records. See DESIGN.md O-7a.
+
+#### Config-driven source onboarding
+
+- [ ] `p2` - **ID**: `cpt-cf-bss-rate-provider-fr-config-onboarding`
+
+Adding, removing, or reordering rate sources **MUST** be a configuration change. A plain
+REST JSON rate feed **MUST** be onboardable with no code change.
+
+- **Rationale**: Provider procurement is an ops decision (DESIGN O-10); billing must not
+  need a release to switch or add a feed.
+- **Actors**: `cpt-cf-bss-rate-provider-actor-platform-operator`
+- **As implemented:** "configuration change" means deploying/configuring a source-plugin
+  gear with a `vendor` + `priority`, not editing one shared list — see DESIGN.md §3.2.
+
+#### Strict configuration validation
+
+- [ ] `p2` - **ID**: `cpt-cf-bss-rate-provider-fr-strict-config-validation`
+
+Invalid *per-plugin* configuration — e.g. the http-json plugin's `mapping` missing, a
+non-`https` `base_url`, or an unusable authentication setup — **MUST** fail that plugin gear's
+own startup loudly, not surface at first fetch.
+
+- **Rationale**: A misconfigured rate feed discovered at fetch time silently degrades
+  billing; startup is the cheapest place to fail for what a single gear's own `init()` can
+  check.
+- **Actors**: `cpt-cf-bss-rate-provider-actor-platform-operator`
+- **As implemented — authentication is checked even earlier than startup:** the credential is
+  carried by the `auth` variant that needs it, so "a kind that needs a key, with no key" and
+  "a key that would never be sent" are **config-load (deserialization) errors** rather than
+  runtime checks in `init()`. Invalid states are unrepresentable instead of validated.
+- **As implemented — narrower than the original wording:** there is no single "source
+  list" or "source kind" anymore (see DESIGN.md's Implementation-revision note and §3.2),
+  so **an unknown source kind and an empty source list are no longer things to validate at
+  all** — a `RateProviderV1` source is a plugin crate, not a config value, so there's no
+  "unknown kind" to reject. Zero matching source plugins for the configured vendor is now a
+  **first-fetch runtime error**, not a startup failure (§3.2's "Empty result is a runtime
+  error" — deliberately, so plugin registration order never has to be enforced). A
+  `vendor` mismatch between the core gear and a source plugin is not rejected anywhere
+  either — it is filtered out, since one registry can legitimately hold source plugins
+  belonging to another composite. Because that exclusion is otherwise invisible and a
+  `vendor` typo passes every startup check, it must stay **observable**: each excluded
+  instance is logged at `debug` (not `warn` — discovery re-runs every tick, so a per-tick
+  warning per foreign instance would be noise in a healthy deployment), and if the filter
+  empties the whole set the resulting first-fetch error names both the expected vendor and
+  the vendors actually present. A *matching*-vendor instance whose scoped client can't be
+  resolved is logged as a warning instead — the two cases are handled differently. Only
+  the http-json plugin's own two config checks above are still startup-time failures
+  today.
+
+## 6. Non-Functional Requirements
+
+Project-wide NFR baselines follow the repository [`guidelines/`](../../../../guidelines/)
+and the parent [ledger PRD](../../ledger/docs/PRD.md) §7; gear-specific NFRs below.
+
+### 6.1 Gear-Specific NFRs
+
+#### Off the posting path
+
+- [ ] `p1` - **ID**: `cpt-cf-bss-rate-provider-nfr-off-posting-path`
+
+A provider outage **MUST NOT** affect posting latency or availability *synchronously*:
+the gear is consumed only by the ledger's background sync job, never on the posting
+path. The guarantee is about synchronous impact only — an outage that outlasts the
+ledger's staleness thresholds degrades FX posts (and only FX posts) through the
+ledger's own fail-safe, `FX_RATE_UNAVAILABLE` (§9's all-sources-down criterion states
+the exact blocking condition and the thresholds that set the tolerated window).
+
+- **Threshold**: Zero posting-path invocations; provider downtime affects FX posts only
+  through the ledger's staleness fail-safe (block, not guess) and never non-FX posting.
+- **Rationale**: Hard isolation requirement inherited from the ledger's post-path NFRs.
+
+#### Fail-safe by absence
+
+- [ ] `p1` - **ID**: `cpt-cf-bss-rate-provider-nfr-fail-safe-absence`
+
+When no source can serve, the gear **MUST** return an error — never fabricated data, never a
+document stitched together from several sources, never silently stale data — so the ledger
+blocks FX posts and alarms instead of posting a wrong rate.
+
+This is about what may be returned **instead of an error**; it does not make partial coverage
+a failure. A source that serves fewer pairs than requested, or whose parse skipped individual
+invalid entries, has succeeded (`cpt-cf-bss-rate-provider-fr-ordered-source-fallback`,
+DESIGN O-13).
+
+- **Threshold**: 100% of all-sources-failed fetches surface as errors to the caller.
+- **Rationale**: `cpt-cf-bss-ledger-fr-fx-rate-source-failure` forbids silent fallback;
+  the adapter must not undermine it upstream.
+
+#### Deterministic rate conversion
+
+- [ ] `p1` - **ID**: `cpt-cf-bss-rate-provider-nfr-deterministic-conversion`
+
+Converting a published decimal rate into the contract's fixed-precision integer form
+**MUST** be deterministic: the same published value always yields the same integer, using
+exact-decimal arithmetic with banker's rounding (half-to-even) and explicit overflow
+errors. A converted rate **MUST** be strictly positive.
+
+- **Threshold**: Golden-vector equality on repeated conversion, including exact half-way
+  decimals; overflow / non-numeric input always errors, never truncates; a value that
+  rounds to zero or below always errors, never reaches a rate store.
+- **Rationale**: Inherits the ledger's platform rounding default
+  (`cpt-cf-bss-ledger-fr-money-rounding-scale`), so a converted rate and the amount posted
+  from it round identically; auditors must be able to reproduce rates.
+
+**Rounding is not this gear's decision to make.** Half-to-even is the platform default
+fixed by the ledger (`cpt-cf-bss-ledger-fr-money-rounding-scale`, `p1`), which requires it
+identically across S1–S6 and exports. This adapter inherits it so converted rates match
+posted amounts; deviating would break that requirement, not merely differ from it.
+Finance / audit sign-off is therefore **not a release gate for this gear** — it is tracked
+against the ledger's platform decision. The only event that would revise the strategy here
+is a change to that ledger requirement, which this adapter would then follow.
+  The positivity rule is a product decision confirmed with the BSS billing owner
+  (2026-07-28): there are no zero or negative FX rates in this domain, so such a value can
+  only be corrupt feed data — and it would zero out or flip the sign of every translation
+  derived from it.
+
+#### Fetch latency
+
+- [ ] `p2` - **ID**: `cpt-cf-bss-rate-provider-nfr-fetch-latency`
+
+A fetch against one source **MUST** complete one bounded attempt within its configured
+timeout; a successful fetch completes fast enough that feed freshness holds within one
+ledger sync tick.
+
+- **Threshold**: p95 ≤ 2 s per source (draft; confirm against ECB response times);
+  worst-case composite duration bounded by the sum of configured per-source timeouts.
+- **Rationale**: Background job budget; G10 pairs must not cross the ledger's 24 h
+  staleness window under normal operation.
+- **Architecture Allocation**: See DESIGN.md § NFR Allocation.
+
+### 6.2 NFR Exclusions
+
+- **Horizontal scalability**: not applicable — one lightweight fetch per ledger sync tick;
+  no request fan-in.
+- **Data durability**: not applicable — the gear is stateless; durability is the ledger's.
+
+## 7. Public Library Interfaces
+
+### 7.1 Public API Surface
+
+#### `RateProviderV1` implementation
+
+- [ ] `p1` - **ID**: `cpt-cf-bss-rate-provider-interface-rate-provider-v1`
+
+- **Type**: Rust trait implementation (`bss-ledger-sdk` `RateProviderV1`,
+  GTS `gts.cf.bss.ledger.rate-provider.v1`), registered in the platform `ClientHub`.
+- **Stability**: stable
+- **Description**: The gear's only consumable surface — latest-rates fetch and health
+  probe. Provider identity is not a separate surface: it arrives as per-rate provenance
+  (`ProviderRate.provider`, the serving source's id) on every returned rate, while
+  `provider_id()` is only this gear's constant configured id — it never says who served
+  a fetch. The health probe is **reachability only**: it reports the
+  endpoint answered, which any HTTP status proves, and says nothing about whether a usable
+  document could be fetched. Feed freshness is a separate signal and MUST NOT be inferred
+  from it (see DESIGN § "Interfaces & contracts").
+- **Breaking Change Policy**: The contract is owned by the ledger SDK; this gear never
+  changes it unilaterally.
+
+### 7.2 External Integration Contracts
+
+#### Provider feed contract
+
+- [ ] `p2` - **ID**: `cpt-cf-bss-rate-provider-contract-provider-feed`
+
+- **Direction**: required from external rate providers.
+- **Protocol/Format**: HTTPS GET returning a parseable rate document (ECB daily XML, or
+  JSON for config-mapped REST feeds) that includes a publication timestamp.
+- **Compatibility**: Feed format changes are absorbed in this gear (parser / mapping
+  config); consumers are insulated by the `RateProviderV1` contract.
+
+## 8. Use Cases
+
+### Fallback serve with provenance
+
+- [ ] `p2` - **ID**: `cpt-cf-bss-rate-provider-usecase-fallback-serve`
+
+**Actor**: `cpt-cf-bss-rate-provider-actor-ledger-rate-sync`
+
+**Preconditions**:
+- Two sources configured in order (primary, fallback); primary is unreachable.
+
+**Main Flow**:
+1. The ledger sync job requests the latest rates.
+2. The gear tries the primary source; the attempt fails within its timeout.
+3. The gear tries the fallback source and receives a whole rate document.
+4. The gear returns that document; every rate in it already carries the fallback source's
+   id as its `provider`, stamped by that source.
+5. The ledger stores each rate under the `provider` the rate itself carries.
+
+**Postconditions**:
+- Ledger rate rows record the fallback provider and the provider's publication time.
+
+**Alternative Flows**:
+- **All sources fail**: the gear returns the last error; the ledger alarms and FX posts
+  block (fail-safe by absence).
+
+### Onboard a new REST feed by configuration
+
+- [ ] `p2` - **ID**: `cpt-cf-bss-rate-provider-usecase-onboard-feed`
+
+**Actor**: `cpt-cf-bss-rate-provider-actor-platform-operator`
+
+**Preconditions**:
+- ECB is configured and serving; the ledger's `RateSyncJob` is ticking.
+- The new feed is a plain GET-JSON endpoint reachable over https.
+
+**Main Flow**:
+1. The operator adds an `bss-rate-provider-http-json-plugin` config block: `base_url`,
+   `mapping`, `auth`, the core gear's `vendor`, and a `priority` that places the feed in
+   the intended fallback position.
+2. The plugin gear starts and registers its `RateProviderSourcePluginSpecV1` instance plus
+   its scoped client.
+3. On its next tick the core gear's discovery lists the instance, keeps it (vendor match),
+   and orders it by `priority`.
+4. The composite serves from it whenever the sources ahead of it fail.
+5. Rates it serves reach the ledger's store stamped with that source's `id`.
+
+**Postconditions**:
+- The feed participates in the fallback chain at its configured position.
+- No consuming module was rebuilt, reconfigured, or restarted — not the core gear, not the
+  ledger. Discovery re-runs per tick and caches nothing, which is what makes this true.
+
+**Alternative Flows**:
+- **Registration lands mid-tick**: the tick that saw no instance yet fails; the next tick
+  picks the feed up. No restart is needed to recover.
+
+## 9. Acceptance Criteria
+
+- [ ] With the adapter deployed and ECB configured, one ledger sync tick populates the
+  ledger's rate store and an invoice post on a directly published pair (EUR-functional
+  tenant) locks a rate (no `FX_RATE_UNAVAILABLE`). Posting for a non-EUR functional
+  currency is out of scope until the ledger triangulation/inversion companion change
+  lands — it is not a criterion this gear can satisfy alone.
+- [ ] With all sources down, the sync tick fails, the feed-freshness alarm fires, and
+  non-FX posting is unaffected. FX posting is **not** immediately blocked: this gear is
+  off the posting path, and the ledger locks rates from its own store. A post blocks with
+  `FX_RATE_UNAVAILABLE` only once that store has no rate for the pair, or the rate it has
+  has crossed the ledger's staleness threshold (`stale_g10_hours` / `stale_default_max_days`).
+  So the outage window a deployment tolerates is set by the ledger's staleness rule, not by
+  this gear.
+- [ ] After a primary-source outage with a healthy fallback, synced rows record the
+  fallback provider's identity.
+- [ ] Re-fetching an identical published document yields byte-identical integer rates.
+- [ ] A new plain REST feed is onboarded by configuration alone: an http-json plugin block
+  with a `base_url`, `mapping`, a `priority`, and a `vendor` equal to the core gear's
+  `source_vendor` (without that match, discovery never selects the plugin) puts the feed
+  into the fallback chain at that position — plus the matching `auth` kind carrying its
+  `api_key` when the feed requires a credential (a credential-bearing feed is onboarded
+  only once the dump-redaction dependency in §10 is met — see the §12 risk). Its rates
+  reach the ledger's store stamped with its own `id`, and no
+  consuming module is rebuilt, reconfigured or restarted to make that happen — neither the
+  core gear nor the ledger. This is the success path behind the "cheap provider onboarding"
+  goal (§1.3); the criterion below only establishes that *mis*configuration fails loudly,
+  which is not the same claim. It rests on discovery re-running every tick and caching
+  nothing, so a change here breaks the goal.
+- [ ] An http-json plugin configured without a `mapping` fails that plugin's own gear
+  startup with a clear error; an `auth` block naming a credential-bearing kind without a
+  key (or attaching a key to the no-auth kind) fails even earlier, at config load.
+- [ ] Ledger rate rows record the source that actually served each rate, and stay correct
+  even when a second consumer fetches from the same adapter concurrently.
+- [ ] A currency code the feed publishes that is not an ISO-4217-shaped identifier is
+  dropped and logged, never written into a tenant's rate store.
+- [ ] A feed serving a document dated more than 26 hours ahead of the gear's clock fails
+  that source's fetch with an error naming the offending timestamp; nothing from it is
+  stored, and the composite falls through to the next source. A document dated up to a full
+  day ahead — the legitimate case for a date-only feed anchored at 00:00 UTC — still serves.
+  Both bounds are asserted, because a test for the far-future case alone would pass with the
+  window set arbitrarily narrow.
+- [ ] With zero source plugins registered for the core gear's configured `source_vendor`,
+  the first `RateSyncJob` tick's `fetch_latest` errors — never a startup crash — and a
+  source plugin registering by a later tick self-heals it. There is no "unknown
+  kind"/"empty list"/"precedence mismatch" startup check anymore; those concepts don't
+  exist in the current design (see DESIGN.md's Implementation-revision note).
+
+## 10. Dependencies
+
+| Dependency | Description | Criticality |
+|------------|-------------|-------------|
+| `bss-ledger-sdk` | Owns the `RateProviderV1` contract and its types | p1 |
+| `types-registry` / `types-registry-sdk` | Plugin discovery + registration substrate every crate here uses (as implemented — plugin pattern, see DESIGN.md) | p1 |
+| Billing Ledger (`RateSyncJob`) | Sole consumer; pulls and persists the rates | p1 |
+| ECB reference-rate feed | Primary external source (free daily publication) | p1 |
+| Ledger triangulation companion change | Required for non-EUR-functional tenants (DESIGN §4) | p1 |
+| Dump-side credential redaction in `toolkit::bootstrap::config::dump` | Prerequisite for **enabling credential-bearing (authenticated http-json) feeds**: the dump serializes pre-deserialization values, so until it redacts credential-shaped fields, no feed whose config carries an `api_key` is onboarded (§12). Owned by the platform / `toolkit` maintainers. Does not gate v1 as shipped (ECB only, no credential) | p1 |
+| Bank / PSP rate feed | Future fallback source; procurement owned by ops | p3 |
+
+## 11. Assumptions
+
+- The ECB daily reference-rate feed remains publicly available at no cost.
+- Source configuration is operator-supplied and platform-trusted (not tenant input).
+- No assumption is made about how many callers share the composite. It is registered
+  process-wide in `ClientHub`, so a second consumer may fetch between any two calls; that
+  is precisely why provenance travels on each rate rather than being read back through a
+  later `provider_id()` call.
+
+## 12. Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| ECB feed outage with no fallback configured (v1 is ECB-only) | FX posts block until feed recovers | Fail-safe by absence + ledger alarm; fallback mechanism is config-ready (deploy/configure another source-plugin gear) |
+| EUR-based pairs only until ledger triangulation/inversion lands | Non-EUR-functional tenants cannot post FX | Sequencing tracked as a hard companion dependency (DESIGN §4) |
+| Provider format drift breaks parsing | Fetch fails, feed goes stale | Whole-document parse failure surfaces as an error → fallback / alarm, never a fabricated or cross-source-stitched document. Drift that invalidates only *some* entries leaves the rest serving (by design — DESIGN O-13); those pairs stop being refreshed and age out into the ledger's `FX_RATE_UNAVAILABLE` |
+| A raw effective-config dump discloses a source's API key | A routine diagnostic leaks a provider credential into logs or a support bundle | `SecretString` redacts the *typed* config, but `toolkit::bootstrap::config::dump` serializes the pre-deserialization JSON, so it is not covered. The documented path keeps the raw key out of the file (`api_key: "${VAR}"`, expanded inside the gear at `init()` via `config_expanded` — implemented and tested), but that path is a convention, not an enforced guarantee: a key hardcoded against it is disclosed verbatim by a routine dump. Dump-side redaction of credential-shaped fields is therefore a **p1 prerequisite for enabling credential-bearing feeds** (tracked in §10), owed by the **platform / `toolkit` owners** — the fix has to sit in the dump itself (see DESIGN §2.2 "Secrets handling"). v1 as shipped is unaffected: the only configured source is ECB, a public feed with no credential. |
+
+## 13. Open Questions
+
+- Concrete bank / PSP fallback feed and credentials — ops procurement (DESIGN O-10).
+
+## 14. Traceability
+
+- **Design**: [DESIGN.md](./DESIGN.md) — self-contained technical design for this gear.
+- **Upstream PRD**: [`../../ledger/docs/PRD.md`](../../ledger/docs/PRD.md) — § Money,
+  Rounding & Foreign Exchange (`cpt-cf-bss-ledger-fr-multi-currency-fx`,
+  `cpt-cf-bss-ledger-fr-fx-rate-source-failure`,
+  `cpt-cf-bss-ledger-fr-money-rounding-scale`).
+- **Consuming design**:
+  [`../../ledger/docs/design/06-fx-multicurrency.md`](../../ledger/docs/design/06-fx-multicurrency.md)
+  — the fetch-time rate-source-fallback algorithm this gear realizes.

--- a/gears/bss/rate-provider/plugins/ecb-plugin/Cargo.toml
+++ b/gears/bss/rate-provider/plugins/ecb-plugin/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "bss-rate-provider-ecb-plugin"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+description = "BSS FX rate-provider ECB source plugin: fetches ECB daily reference rates and registers as a RateProviderV1 plugin instance"
+
+[lints]
+workspace = true
+
+[dependencies]
+# Shared source utilities (conversion, error mapping, metrics) + the source-plugin GTS spec.
+bss-rate-provider-sdk = { workspace = true }
+# The RateProviderV1 contract this source implements + its types.
+bss-ledger-sdk = { workspace = true }
+# The `deps = [types_registry]` gear-macro edge re-exports `::types_registry`, so
+# the gear crate must be a direct dependency (init-ordering; not used in code).
+types-registry = { workspace = true }
+# Gear macro, GearCtx, ClientHub/ClientScope, gts::PluginV1, config.
+toolkit = { workspace = true }
+# SecurityContext in the fetch_latest signature.
+toolkit-security = { workspace = true }
+# Outbound HTTPS client.
+toolkit-http = { workspace = true, features = ["otel"] }
+# inventory::submit! emitted by the gear macro.
+inventory = { workspace = true }
+
+async-trait = { workspace = true }
+anyhow = { workspace = true }
+tracing = { workspace = true }
+serde = { workspace = true }
+# NaiveDate / DateTime<Utc> for as_of; no `clock` feature.
+chrono = { workspace = true }
+# ECB daily reference-rate XML parsing.
+quick-xml = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }
+# In-process HTTP server for the integration test.
+axum = { workspace = true }

--- a/gears/bss/rate-provider/plugins/ecb-plugin/src/config.rs
+++ b/gears/bss/rate-provider/plugins/ecb-plugin/src/config.rs
@@ -1,0 +1,35 @@
+//! ECB source-plugin configuration.
+
+use serde::Deserialize;
+
+/// Config for the ECB source plugin (`config:` block under `bss-rate-provider-ecb-plugin:`).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct EcbPluginConfig {
+    /// Stable `provider_id` stamped on synced ledger rows (design O-8 default "ecb").
+    pub id: String,
+    /// Plugin-selection vendor (must match the core gear's configured vendor).
+    pub vendor: String,
+    /// Fallback order across sources: lower `priority` is tried first by the composite.
+    pub priority: i16,
+    /// ECB daily reference-rate feed URL (MUST be https).
+    pub base_url: String,
+    /// Outbound per-attempt HTTP timeout in milliseconds.
+    pub timeout_ms: u64,
+}
+
+impl Default for EcbPluginConfig {
+    fn default() -> Self {
+        Self {
+            id: "ecb".to_owned(),
+            vendor: "cf.bss".to_owned(),
+            priority: 100,
+            base_url: "https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml".to_owned(),
+            timeout_ms: 5000,
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "config_tests.rs"]
+mod tests;

--- a/gears/bss/rate-provider/plugins/ecb-plugin/src/config_tests.rs
+++ b/gears/bss/rate-provider/plugins/ecb-plugin/src/config_tests.rs
@@ -1,0 +1,37 @@
+//! Default-configuration tests.
+//!
+//! The defaults are load-bearing, not cosmetic: an empty `config:` block deploys
+//! this plugin entirely on them (see the gear's config gate), so each value is
+//! part of the shipped behaviour rather than an internal detail.
+
+use bss_rate_provider_sdk::http_client::build_source_http_client;
+
+use super::EcbPluginConfig;
+
+#[test]
+fn defaults_deploy_a_working_ecb_source() {
+    let cfg = EcbPluginConfig::default();
+    // Must match the core gear's `source_vendor` default, or an otherwise-empty
+    // deployment discovers no sources at all on its first tick.
+    assert_eq!(cfg.vendor, "cf.bss");
+    assert_eq!(cfg.id, "ecb");
+    // ECB is the primary source, so it sits ahead of the http-json plugin's
+    // default 200 in the composite's fallback order.
+    assert_eq!(cfg.priority, 100);
+    assert_eq!(
+        cfg.base_url,
+        "https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml"
+    );
+    assert_eq!(cfg.timeout_ms, 5000);
+}
+
+/// `#[tokio::test]`, because building the client registers with the async
+/// runtime's reactor — the same thing `init()` does.
+#[tokio::test]
+async fn the_defaults_pass_this_plugins_own_startup_gate() {
+    // `build_source_http_client` rejects a non-https `base_url` and a timeout
+    // outside (0, MAX_TIMEOUT_MS]. Defaults that failed either would make an
+    // empty `config:` block abort the gear at init instead of deploying.
+    let cfg = EcbPluginConfig::default();
+    assert!(build_source_http_client(&cfg.base_url, cfg.timeout_ms).is_ok());
+}

--- a/gears/bss/rate-provider/plugins/ecb-plugin/src/gear.rs
+++ b/gears/bss/rate-provider/plugins/ecb-plugin/src/gear.rs
@@ -1,0 +1,98 @@
+//! ECB source-plugin gear: build the source, register a `PluginV1` instance in
+//! the types-registry, and register the scoped `RateProviderV1` client keyed by
+//! the GTS instance id (the pattern the core `bss-rate-provider` gear discovers).
+
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use bss_ledger_sdk::RateProviderV1;
+use bss_rate_provider_sdk::RateProviderSourcePluginSpecV1;
+use bss_rate_provider_sdk::http_client::build_source_http_client;
+use bss_rate_provider_sdk::metrics::{OtelFetchMetrics, SharedFetchMetrics};
+use bss_rate_provider_sdk::registration::register_rate_provider_plugin;
+use toolkit::Gear;
+use toolkit::config::ConfigError;
+use toolkit::context::GearCtx;
+use tracing::info;
+
+use crate::config::EcbPluginConfig;
+use crate::infra::source::EcbRateProvider;
+
+/// Stable GTS instance segment appended to the source-plugin type id. Must be a
+/// single valid GTS segment (`vendor.name.plugin.vN`, 5 dot-components) — a
+/// 6-component id fails `GtsId` parsing and would be rejected by the registry.
+const INSTANCE_SEGMENT: &str = "cf.bss.rate_provider_ecb.plugin.v1";
+
+/// The ECB source-plugin gear.
+#[toolkit::gear(name = "bss-rate-provider-ecb-plugin", deps = [types_registry])]
+pub struct EcbRateProviderPlugin;
+
+impl Default for EcbRateProviderPlugin {
+    fn default() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl Gear for EcbRateProviderPlugin {
+    async fn init(&self, ctx: &GearCtx) -> Result<()> {
+        // Config gate (bss subsystem convention): absent from `gears:` => inert;
+        // present-but-empty => defaults; present-but-invalid => abort loudly.
+        let cfg: EcbPluginConfig = match ctx.config::<EcbPluginConfig>() {
+            Ok(cfg) => cfg,
+            Err(ConfigError::MissingConfigSection { .. }) => EcbPluginConfig::default(),
+            Err(ConfigError::GearNotFound { .. }) => {
+                info!("bss-rate-provider-ecb-plugin: not configured; skipping registration");
+                return Ok(());
+            }
+            Err(e) => return Err(e).context("bss-rate-provider-ecb-plugin: invalid config"),
+        };
+
+        let client = build_source_http_client(&cfg.base_url, cfg.timeout_ms)
+            .context("bss-rate-provider-ecb-plugin: build HTTP client")?;
+        let metrics: SharedFetchMetrics = Arc::new(OtelFetchMetrics::from_global());
+        let source: Arc<dyn RateProviderV1> = Arc::new(EcbRateProvider::new(
+            cfg.id.clone(),
+            cfg.base_url.clone(),
+            client,
+            metrics,
+        ));
+
+        // Publish the plugin instance (priority = fallback order) to types-registry
+        // and register the scoped client the core gear resolves via the instance id.
+        let instance_id = register_rate_provider_plugin::<RateProviderSourcePluginSpecV1>(
+            ctx,
+            INSTANCE_SEGMENT,
+            cfg.vendor.clone(),
+            cfg.priority,
+            source,
+        )
+        .await?;
+
+        info!(
+            provider = %cfg.id,
+            instance_id = %instance_id,
+            priority = cfg.priority,
+            "bss-rate-provider-ecb-plugin: registered ECB source plugin"
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod gts_id_tests {
+    use bss_rate_provider_sdk::RateProviderSourcePluginSpecV1;
+    use bss_rate_provider_sdk::registration::assert_registration_builds_valid_gts_id;
+
+    /// The built plugin instance id must parse as a valid GTS id — a segment with
+    /// too many dot-components fails `GtsId` parsing and the registry rejects it.
+    #[test]
+    fn instance_id_parses_as_gts() {
+        assert_registration_builds_valid_gts_id::<RateProviderSourcePluginSpecV1>(
+            super::INSTANCE_SEGMENT,
+            "cf.bss",
+            100,
+        );
+    }
+}

--- a/gears/bss/rate-provider/plugins/ecb-plugin/src/infra/mod.rs
+++ b/gears/bss/rate-provider/plugins/ecb-plugin/src/infra/mod.rs
@@ -1,0 +1,4 @@
+//! Infrastructure layer — the outbound ECB feed adapter (HTTP fetch + XML parse
+//! + `rate_micro` conversion) behind the ledger's `RateProviderV1` contract.
+
+pub mod source;

--- a/gears/bss/rate-provider/plugins/ecb-plugin/src/infra/source.rs
+++ b/gears/bss/rate-provider/plugins/ecb-plugin/src/infra/source.rs
@@ -1,0 +1,454 @@
+//! `EcbRateProvider` — HTTP fetch + XML parse + `rate_micro` conversion over the
+//! ECB daily reference-rate feed. Direct pairs only (design O-3): a requested
+//! pair the feed does not publish is omitted, never synthesized or inverted.
+
+use std::collections::HashSet;
+
+use async_trait::async_trait;
+use bss_ledger_sdk::{CurrencyPair, ProviderRate, RateProviderError, RateProviderV1};
+use bss_rate_provider_sdk::conversion::rate_to_micro;
+use bss_rate_provider_sdk::currency::normalize_currency;
+use bss_rate_provider_sdk::error::map_http_error;
+use bss_rate_provider_sdk::fetch::fetch_and_parse;
+use bss_rate_provider_sdk::metrics::SharedFetchMetrics;
+use bss_rate_provider_sdk::publication_time::reject_future_publication_time;
+use chrono::{NaiveDate, NaiveTime, Utc};
+use quick_xml::events::{BytesStart, Event};
+use quick_xml::reader::Reader;
+use toolkit_http::HttpClient;
+use toolkit_security::SecurityContext;
+
+/// ECB publishes EUR-based pairs (EUR -> currency).
+const ECB_BASE: &str = "EUR";
+
+/// A parsed ECB feed: the publication date plus its raw `(currency, rate)` pairs.
+type EcbTable = (NaiveDate, Vec<(String, String)>);
+
+/// Parse the ECB daily XML into a publication date and raw `(currency, rate)` pairs.
+///
+/// The daily feed is one day's rates, so a second *distinct* publication date
+/// fails the whole document: it means this is some other file (most likely the
+/// 90-day history feed behind a mistyped `base_url`), there is no non-arbitrary
+/// way to pick a date, and failing lets the composite move on to the next source.
+/// A repeat of the *same* date is fine. A duplicate currency entry is only logged
+/// — the first occurrence wins.
+///
+/// Currency rows are kept only while nested inside the publication date's
+/// `<Cube time="...">` block, so a row after that block's `</Cube>`, or one under
+/// a `time` that failed to parse, is omitted rather than stamped with an `as_of`
+/// that isn't its own.
+///
+/// # Errors
+/// [`RateProviderError::Internal`] on malformed XML, a missing `time` date, more
+/// than one distinct `time` date, or an empty rate table.
+pub fn parse_ecb_xml(bytes: &[u8]) -> Result<EcbTable, RateProviderError> {
+    let mut reader = Reader::from_reader(bytes);
+    let mut buf = Vec::new();
+    let mut date: Option<NaiveDate> = None;
+    let mut current_date: Option<NaiveDate> = None;
+    let mut rates: Vec<(String, String)> = Vec::new();
+    let mut seen_currencies: HashSet<String> = HashSet::new();
+    // Nesting depth of open `<Cube>` elements, and the depth of the retained
+    // date's Cube. Comparing dates alone cannot tell a row *inside* that block
+    // from a sibling that follows its `</Cube>`, because `current_date` outlives
+    // the element it came from.
+    let mut depth: usize = 0;
+    let mut retained_depth: Option<usize> = None;
+    loop {
+        let event = reader
+            .read_event_into(&mut buf)
+            .map_err(|e| RateProviderError::Internal(format!("ECB XML parse: {e}")))?;
+        match event {
+            // The date lives on the outer `<Cube time="...">` and each inner
+            // `<Cube currency="X" rate="Y"/>` is one EUR-based pair — both are
+            // `Cube` elements, so inspect every `Cube`'s attributes.
+            Event::Start(e) if e.local_name().as_ref() == b"Cube" => {
+                depth += 1;
+                let (time, currency, rate) = read_cube_attributes(&e);
+                if let Some(value) = time {
+                    current_date = update_publication_date(&mut date, &value)?;
+                    // Only a `Start` can open the block that owns recordable
+                    // rows: a self-closing Cube encloses nothing.
+                    if retained_depth.is_none() && is_retained_date(current_date, date) {
+                        retained_depth = Some(depth);
+                    }
+                }
+                record_cube_row(
+                    &mut seen_currencies,
+                    &mut rates,
+                    keep_row(retained_depth, current_date, date),
+                    currency,
+                    rate,
+                );
+            }
+            // Self-closing: encloses nothing, so it never changes depth.
+            Event::Empty(e) if e.local_name().as_ref() == b"Cube" => {
+                let (time, currency, rate) = read_cube_attributes(&e);
+                if let Some(value) = time {
+                    current_date = update_publication_date(&mut date, &value)?;
+                }
+                record_cube_row(
+                    &mut seen_currencies,
+                    &mut rates,
+                    keep_row(retained_depth, current_date, date),
+                    currency,
+                    rate,
+                );
+            }
+            Event::End(e) if e.local_name().as_ref() == b"Cube" => {
+                if retained_depth == Some(depth) {
+                    retained_depth = None;
+                }
+                // `saturating_sub`: a stray `</Cube>` in a malformed document
+                // must not underflow the counter.
+                depth = depth.saturating_sub(1);
+            }
+            Event::Eof => break,
+            _ => {}
+        }
+        buf.clear();
+    }
+    let date = date.ok_or_else(|| {
+        RateProviderError::Internal("ECB XML missing publication date".to_owned())
+    })?;
+    if rates.is_empty() {
+        return Err(RateProviderError::Internal(
+            "ECB XML contained no rate entries".to_owned(),
+        ));
+    }
+    Ok((date, rates))
+}
+
+/// Whether `current` is a parsed date that is the retained one.
+///
+/// `is_some()` matters as much as the equality: before any date is seen both
+/// sides are `None` and compare equal, which would let a row that arrived first
+/// inherit a date a later block establishes.
+fn is_retained_date(current: Option<NaiveDate>, retained: Option<NaiveDate>) -> bool {
+    current.is_some() && current == retained
+}
+
+/// Whether a `(currency, rate)` row may be recorded. Both halves are needed:
+///
+/// * `retained_depth.is_some()` — the row sits **inside** the still-open date
+///   block, so a sibling Cube after that block's `</Cube>` cannot inherit the
+///   closed block's `as_of`.
+/// * [`is_retained_date`] — the enclosing block carries the document's own date,
+///   so a row under an unparseable `time` (or one seen before any date) is not
+///   stamped with a date it never had.
+fn keep_row(
+    retained_depth: Option<usize>,
+    current_date: Option<NaiveDate>,
+    date: Option<NaiveDate>,
+) -> bool {
+    retained_depth.is_some() && is_retained_date(current_date, date)
+}
+
+/// Record one Cube's `(currency, rate)` pair, or log why it was dropped.
+fn record_cube_row(
+    seen: &mut HashSet<String>,
+    rates: &mut Vec<(String, String)>,
+    keep: bool,
+    currency: Option<String>,
+    rate: Option<String>,
+) {
+    match (currency, rate) {
+        (Some(c), Some(r)) => {
+            if keep {
+                record_currency_rate(seen, rates, &c, r);
+            } else {
+                tracing::warn!(
+                    currency = %c,
+                    "bss-rate-provider-ecb: currency entry outside the retained publication \
+                     date's block; omitting rather than mislabeling its as_of"
+                );
+            }
+        }
+        // A real ECB rate `Cube` always carries both. Half a pair (truncated or
+        // malformed feed) is unusable, but still logged: every oddity in this
+        // module leaves a trace.
+        (c @ Some(_), None) | (c @ None, Some(_)) => {
+            tracing::warn!(
+                currency = ?c,
+                "bss-rate-provider-ecb: Cube carries only one of currency/rate; \
+                 ignoring the entry"
+            );
+        }
+        // The outer `<Cube time=...>` and wrapper elements: no currency, no
+        // rate, nothing to report.
+        (None, None) => {}
+    }
+}
+
+/// Pull the `time`, `currency`, and `rate` attribute values off one `<Cube>`
+/// element. A real ECB `Cube` carries `time` XOR `currency`+`rate`, but all three
+/// are read from whichever element shows up.
+fn read_cube_attributes(e: &BytesStart<'_>) -> (Option<String>, Option<String>, Option<String>) {
+    let mut time = None;
+    let mut currency = None;
+    let mut rate = None;
+    for attr in e.attributes().flatten() {
+        let value = String::from_utf8_lossy(attr.value.as_ref()).into_owned();
+        match attr.key.as_ref() {
+            b"time" => time = Some(value),
+            b"currency" => currency = Some(value),
+            b"rate" => rate = Some(value),
+            _ => {}
+        }
+    }
+    (time, currency, rate)
+}
+
+/// Record the document's publication date, or reject the document.
+///
+/// Returns the parsed date so the caller can tell which date-block the following
+/// currency rows sit in. `Ok(None)` means this `Cube`'s `time` was unparseable
+/// and the element carries no usable date.
+///
+/// # Errors
+/// [`RateProviderError::Internal`] when a *second, distinct* date appears (see
+/// [`parse_ecb_xml`]). A repeat of the same date is accepted.
+fn update_publication_date(
+    date: &mut Option<NaiveDate>,
+    value: &str,
+) -> Result<Option<NaiveDate>, RateProviderError> {
+    let parsed = match NaiveDate::parse_from_str(value, "%Y-%m-%d") {
+        Ok(parsed) => parsed,
+        Err(e) => {
+            // Log rather than drop silently: if this is the feed's ONLY date,
+            // parsing later fails with "missing publication date", which
+            // misattributes the cause (unparseable, not absent). The raw value
+            // comes from a public feed, so it is diagnostic data, not a secret.
+            tracing::warn!(
+                value = %value,
+                error = %e,
+                "bss-rate-provider-ecb: unparseable publication date in feed; ignoring this Cube"
+            );
+            return Ok(None);
+        }
+    };
+    match *date {
+        None => *date = Some(parsed),
+        Some(existing) if existing != parsed => {
+            tracing::warn!(
+                previous = %existing,
+                found = %parsed,
+                "bss-rate-provider-ecb: feed contains more than one publication date; \
+                 rejecting the document (is base_url pointing at the history feed?)"
+            );
+            return Err(RateProviderError::Internal(format!(
+                "ECB XML contains more than one publication date ({existing} and {parsed}); \
+                 the daily feed must carry exactly one"
+            )));
+        }
+        Some(_) => {}
+    }
+    Ok(Some(parsed))
+}
+
+/// Keep the first entry for a given currency; a duplicate is logged, not fatal
+/// (see [`parse_ecb_xml`]).
+///
+/// The `currency` attribute arrives verbatim from the remote XML and becomes a
+/// tenant-store column value, so it is gated on the ISO-4217 shape here; a
+/// malformed code is dropped and logged. Dedup keys off the normalized code, so a
+/// feed publishing both `USD` and `usd` is caught as the duplicate it is.
+fn record_currency_rate(
+    seen: &mut HashSet<String>,
+    rates: &mut Vec<(String, String)>,
+    currency: &str,
+    rate: String,
+) {
+    let Some(normalized) = normalize_currency(currency) else {
+        tracing::warn!(
+            currency = %currency,
+            "bss-rate-provider-ecb: feed entry has a non-ISO-4217-shaped currency code; dropping it"
+        );
+        return;
+    };
+    if seen.insert(normalized.clone()) {
+        rates.push((normalized, rate));
+    } else {
+        tracing::warn!(
+            currency = %normalized,
+            "bss-rate-provider-ecb: duplicate currency entry in feed; keeping the first"
+        );
+    }
+}
+
+/// Convert parsed ECB rows into `ProviderRate`s (base = EUR), each stamped with
+/// `provider` as its provenance. When `pairs` is non-empty, keep only the
+/// requested EUR-based quotes (others omitted, not an error). `as_of` is the
+/// publication date at 00:00:00 UTC.
+///
+/// A rate string that fails conversion is skipped (logged with its quote), not
+/// fatal — matching the http-json source. The ledger's `RateSyncJob` treats any
+/// failure from a configured provider as `FX_SNAPSHOT_MISSING` and refreshes
+/// nothing, so one malformed currency would otherwise stall the FX fan-out for
+/// every other currency in an otherwise-good feed.
+///
+/// # Errors
+/// [`RateProviderError::Internal`] when entries were attempted and **all** of
+/// them failed conversion.
+///
+/// [`RateProviderError::PairUnavailable`] when a non-empty `pairs` matched
+/// nothing this feed publishes — the contract's shared answer for "not served
+/// here", identical in the http-json source. It stays an `Err` so the composite
+/// moves on to a source that may publish the pair; `Ok(vec![])` would read as a
+/// complete document and stop the fallback chain here.
+pub fn ecb_rates_to_provider_rates(
+    date: NaiveDate,
+    raw: &[(String, String)],
+    pairs: &[CurrencyPair],
+    provider: &str,
+) -> Result<Vec<ProviderRate>, RateProviderError> {
+    let as_of = date.and_time(NaiveTime::MIN).and_utc();
+    let mut out = Vec::with_capacity(raw.len());
+    let mut skipped: u64 = 0;
+    for (quote, rate_str) in raw {
+        // ISO 4217 codes are ASCII; compare case-insensitively so a caller that
+        // didn't normalize casing (e.g. "usd") still matches a pair ECB
+        // publishes, instead of looking like a genuinely unpublished one.
+        if !pairs.is_empty()
+            && !pairs.iter().any(|p| {
+                p.base.eq_ignore_ascii_case(ECB_BASE) && p.quote.eq_ignore_ascii_case(quote)
+            })
+        {
+            continue;
+        }
+        match rate_to_micro(rate_str) {
+            Ok(rate_micro) => out.push(ProviderRate {
+                base: ECB_BASE.to_owned(),
+                quote: quote.clone(),
+                rate_micro,
+                as_of,
+                provider: provider.to_owned(),
+            }),
+            Err(e) => {
+                skipped += 1;
+                tracing::warn!(
+                    provider,
+                    quote = %quote,
+                    error = %e,
+                    "bss-rate-provider-ecb: skipping entry whose rate failed conversion"
+                );
+            }
+        }
+    }
+    if skipped > 0 {
+        tracing::warn!(
+            provider,
+            skipped,
+            "bss-rate-provider-ecb: skipped unconvertible rate entries"
+        );
+        // Every attempted entry failed: report it rather than pass an empty
+        // table off as a success, which would suppress the composite's fallback.
+        if out.is_empty() {
+            return Err(RateProviderError::Internal(
+                "every ECB rate entry failed conversion".to_owned(),
+            ));
+        }
+    }
+    // Nothing matched a caller-requested pair, so the composite should try the
+    // next source. Named after the first requested pair: with one pair that is
+    // exactly what was missing, with several it is the caller's own first choice.
+    if out.is_empty()
+        && let Some(first) = pairs.first()
+    {
+        return Err(RateProviderError::PairUnavailable {
+            base: first.base.clone(),
+            quote: first.quote.clone(),
+        });
+    }
+    Ok(out)
+}
+
+/// The ECB source.
+pub struct EcbRateProvider {
+    id: String,
+    base_url: String,
+    client: HttpClient,
+    metrics: SharedFetchMetrics,
+}
+
+impl EcbRateProvider {
+    /// Build the source over a shared HTTP client.
+    #[must_use]
+    pub fn new(
+        id: String,
+        base_url: String,
+        client: HttpClient,
+        metrics: SharedFetchMetrics,
+    ) -> Self {
+        Self {
+            id,
+            base_url,
+            client,
+            metrics,
+        }
+    }
+}
+
+#[async_trait]
+impl RateProviderV1 for EcbRateProvider {
+    fn provider_id(&self) -> &str {
+        &self.id
+    }
+
+    async fn fetch_latest(
+        &self,
+        _ctx: &SecurityContext,
+        pairs: &[CurrencyPair],
+        _request_id: &str,
+    ) -> Result<Vec<ProviderRate>, RateProviderError> {
+        let request = self.client.get(&self.base_url);
+        fetch_and_parse(request, &self.id, self.metrics.as_ref(), |bytes| {
+            let (date, raw) = parse_ecb_xml(bytes)?;
+            let as_of = date.and_time(NaiveTime::MIN).and_utc();
+            // A document dated far enough ahead reads as permanently fresh to
+            // the ledger's age-based staleness rule.
+            reject_future_publication_time(as_of, Utc::now(), &self.id)?;
+            let rates = ecb_rates_to_provider_rates(date, &raw, pairs, &self.id)?;
+            Ok((rates, as_of.timestamp()))
+        })
+        .await
+    }
+
+    /// Cheap reachability probe: a HEAD request, never a full fetch+parse. ECB's
+    /// static feed serves HEAD the same as GET, minus the body.
+    ///
+    /// **Any HTTP response is reachable, including a non-2xx one.** A `503` proves
+    /// the request arrived, which is the only question this probe answers; only a
+    /// transport failure (DNS, connect, TLS, timeout) is `Err`. See
+    /// `RateProviderV1::health`. The status is still logged, because "reachable
+    /// but answering 503" is worth seeing.
+    ///
+    /// So a green probe says nothing about whether the body still parses. Feed
+    /// freshness lives on `fx_provider_last_success_timestamp`, which advances
+    /// only on a fetch that actually parsed.
+    async fn health(
+        &self,
+        _ctx: &SecurityContext,
+        _request_id: &str,
+    ) -> Result<(), RateProviderError> {
+        let resp = self
+            .client
+            .head(&self.base_url)
+            .send()
+            .await
+            .map_err(|e| map_http_error(&e))?;
+        if !resp.status().is_success() {
+            tracing::warn!(
+                provider = %self.id,
+                status = resp.status().as_u16(),
+                "bss-rate-provider-ecb: reachability probe answered with a non-success status; \
+                 the host answered, so the probe passes"
+            );
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[path = "source_tests.rs"]
+mod tests;

--- a/gears/bss/rate-provider/plugins/ecb-plugin/src/infra/source_tests.rs
+++ b/gears/bss/rate-provider/plugins/ecb-plugin/src/infra/source_tests.rs
@@ -1,0 +1,447 @@
+//! ECB parser + mapping tests over the daily-XML fixture.
+
+use bss_ledger_sdk::{CurrencyPair, RateProviderError};
+use chrono::{Datelike, NaiveDate, TimeZone, Utc};
+
+use super::{ecb_rates_to_provider_rates, parse_ecb_xml};
+
+const FIXTURE: &[u8] = include_bytes!("../../tests/fixtures/eurofxref-daily.xml");
+
+/// The `provider_id` the mapper stamps onto every rate under test.
+const PROVIDER: &str = "ecb";
+
+#[test]
+fn parses_date_and_all_pairs() {
+    let (date, raw) = parse_ecb_xml(FIXTURE).unwrap();
+    assert_eq!((date.year(), date.month(), date.day()), (2026, 7, 21));
+    assert_eq!(raw.len(), 3);
+    assert!(raw.iter().any(|(c, r)| c == "USD" && r == "1.0856"));
+}
+
+#[test]
+fn whole_table_when_no_pairs_requested() {
+    let (date, raw) = parse_ecb_xml(FIXTURE).unwrap();
+    let rates = ecb_rates_to_provider_rates(date, &raw, &[], PROVIDER).unwrap();
+    assert_eq!(rates.len(), 3);
+    let usd = rates.iter().find(|r| r.quote == "USD").unwrap();
+    assert_eq!(usd.base, "EUR");
+    assert_eq!(usd.rate_micro, 1_085_600);
+    assert_eq!(
+        usd.as_of,
+        Utc.with_ymd_and_hms(2026, 7, 21, 0, 0, 0).unwrap()
+    );
+}
+
+#[test]
+fn every_rate_is_stamped_with_the_serving_provider_id() {
+    // Provenance is per-rate, not read back from a separate `provider_id()` call,
+    // so the ledger records the true upstream on every stored row.
+    let (date, raw) = parse_ecb_xml(FIXTURE).unwrap();
+    let rates = ecb_rates_to_provider_rates(date, &raw, &[], "bank-x").unwrap();
+    assert!(!rates.is_empty());
+    assert!(rates.iter().all(|r| r.provider == "bank-x"));
+}
+
+#[test]
+fn requested_pair_filters_and_omits_unavailable() {
+    let (date, raw) = parse_ecb_xml(FIXTURE).unwrap();
+    let want = vec![
+        CurrencyPair {
+            base: "EUR".to_owned(),
+            quote: "USD".to_owned(),
+        },
+        CurrencyPair {
+            base: "EUR".to_owned(),
+            quote: "CHF".to_owned(),
+        },
+    ];
+    let rates = ecb_rates_to_provider_rates(date, &raw, &want, PROVIDER).unwrap();
+    assert_eq!(rates.len(), 1);
+    assert_eq!(rates[0].quote, "USD");
+}
+
+#[test]
+fn non_xml_input_is_internal_error() {
+    assert!(matches!(
+        parse_ecb_xml(b"not xml"),
+        Err(RateProviderError::Internal(_))
+    ));
+}
+
+#[test]
+fn well_formed_xml_without_cube_entries_is_internal_error() {
+    // Structurally valid XML carrying neither a publication date nor rate entries.
+    assert!(matches!(
+        parse_ecb_xml(b"<a></a>"),
+        Err(RateProviderError::Internal(_))
+    ));
+}
+
+#[test]
+fn case_insensitive_pair_request_still_matches() {
+    // ECB's own codes are uppercase; a caller that didn't normalize casing (e.g.
+    // "usd") must still match the published pair.
+    let (date, raw) = parse_ecb_xml(FIXTURE).unwrap();
+    let want = vec![CurrencyPair {
+        base: "eur".to_owned(),
+        quote: "usd".to_owned(),
+    }];
+    let rates = ecb_rates_to_provider_rates(date, &raw, &want, PROVIDER).unwrap();
+    assert_eq!(rates.len(), 1);
+    assert_eq!(rates[0].quote, "USD");
+}
+
+#[test]
+fn reversed_pair_is_omitted_not_inverted() {
+    // ECB only publishes EUR->X. The inverse leg (X->EUR, which a
+    // non-EUR-functional tenant's ledger needs) must never be synthesized here —
+    // that inversion is the ledger's triangulation job. With no other requested
+    // pair left, the pair-unavailable error lets the composite try a source that
+    // may publish the leg directly.
+    let (date, raw) = parse_ecb_xml(FIXTURE).unwrap();
+    let want = vec![CurrencyPair {
+        base: "USD".to_owned(),
+        quote: "EUR".to_owned(),
+    }];
+    let err = ecb_rates_to_provider_rates(date, &raw, &want, PROVIDER).unwrap_err();
+    assert!(
+        matches!(&err, RateProviderError::PairUnavailable { base, quote } if base == "USD" && quote == "EUR"),
+        "expected PairUnavailable naming the requested leg, got {err:?}"
+    );
+}
+
+#[test]
+fn refetching_the_identical_document_is_deterministic() {
+    // A non-publication day (weekend/holiday) re-serves the same document
+    // unchanged; the adapter must never fabricate a fresher `as_of`.
+    let (date_a, raw_a) = parse_ecb_xml(FIXTURE).unwrap();
+    let (date_b, raw_b) = parse_ecb_xml(FIXTURE).unwrap();
+    let rates_a = ecb_rates_to_provider_rates(date_a, &raw_a, &[], PROVIDER).unwrap();
+    let rates_b = ecb_rates_to_provider_rates(date_b, &raw_b, &[], PROVIDER).unwrap();
+    assert_eq!(rates_a, rates_b);
+}
+
+#[test]
+fn duplicate_currency_entry_keeps_first_and_does_not_error() {
+    const DUPLICATE_CURRENCY_XML: &[u8] = br#"<?xml version="1.0" encoding="UTF-8"?>
+<gesmes:Envelope xmlns:gesmes="http://www.gesmes.org/xml/2002-08-01" xmlns="http://www.ecb.int/vocabulary/2002-08-01/eurofxref">
+  <Cube>
+    <Cube time="2026-07-21">
+      <Cube currency="USD" rate="1.0856"/>
+      <Cube currency="USD" rate="1.2000"/>
+    </Cube>
+  </Cube>
+</gesmes:Envelope>
+"#;
+    let (_date, raw) = parse_ecb_xml(DUPLICATE_CURRENCY_XML).unwrap();
+    let usd_entries: Vec<_> = raw.iter().filter(|(c, _)| c == "USD").collect();
+    assert_eq!(
+        usd_entries.len(),
+        1,
+        "duplicate currency entry must be deduped, not doubled"
+    );
+    assert_eq!(usd_entries[0].1, "1.0856", "the first occurrence must win");
+}
+
+#[test]
+fn a_second_distinct_date_fails_the_whole_document() {
+    // The daily feed is one day's rates, so two dates means this is some other
+    // file — most likely the 90-day history feed behind a mistyped `base_url`.
+    // Picking by document order would quietly serve a subset of the wrong file.
+    const MULTI_DATE_XML: &[u8] = br#"<?xml version="1.0" encoding="UTF-8"?>
+<gesmes:Envelope xmlns:gesmes="http://www.gesmes.org/xml/2002-08-01" xmlns="http://www.ecb.int/vocabulary/2002-08-01/eurofxref">
+  <Cube>
+    <Cube time="2026-07-21">
+      <Cube currency="USD" rate="1.0856"/>
+    </Cube>
+    <Cube time="2026-07-20">
+      <Cube currency="JPY" rate="160.85"/>
+    </Cube>
+  </Cube>
+</gesmes:Envelope>
+"#;
+    let err = parse_ecb_xml(MULTI_DATE_XML).unwrap_err();
+    assert!(
+        matches!(err, RateProviderError::Internal(ref m)
+            if m.contains("2026-07-21") && m.contains("2026-07-20")),
+        "the rejection must name both dates so the operator can see which files collided: {err:?}"
+    );
+}
+
+#[test]
+fn a_repeated_identical_date_is_not_a_conflict() {
+    // The same date stated twice is redundant, not contradictory, and every row
+    // still belongs to it — failing would reject a valid, if odd, feed.
+    const REPEATED_DATE_XML: &[u8] = br#"<?xml version="1.0" encoding="UTF-8"?>
+<gesmes:Envelope xmlns:gesmes="http://www.gesmes.org/xml/2002-08-01" xmlns="http://www.ecb.int/vocabulary/2002-08-01/eurofxref">
+  <Cube>
+    <Cube time="2026-07-21">
+      <Cube currency="USD" rate="1.0856"/>
+    </Cube>
+    <Cube time="2026-07-21">
+      <Cube currency="JPY" rate="160.85"/>
+    </Cube>
+  </Cube>
+</gesmes:Envelope>
+"#;
+    let (date, raw) = parse_ecb_xml(REPEATED_DATE_XML).unwrap();
+    assert_eq!((date.year(), date.month(), date.day()), (2026, 7, 21));
+    assert_eq!(raw.len(), 2, "both blocks' rows belong to the same date");
+}
+
+#[test]
+fn a_self_closing_dated_cube_still_establishes_the_publication_date() {
+    // A `<Cube time="…"/>` that encloses nothing is a different XML event than an
+    // opening tag, so the date has to be read on both. Otherwise the document's
+    // only date could be silently skipped and the parse would fail as "missing
+    // publication date" against a feed that plainly states one.
+    const SELF_CLOSING_DATE_XML: &[u8] = br#"<?xml version="1.0" encoding="UTF-8"?>
+<gesmes:Envelope xmlns:gesmes="http://www.gesmes.org/xml/2002-08-01" xmlns="http://www.ecb.int/vocabulary/2002-08-01/eurofxref">
+  <Cube>
+    <Cube time="2026-07-21"/>
+    <Cube time="2026-07-21">
+      <Cube currency="USD" rate="1.0856"/>
+    </Cube>
+  </Cube>
+</gesmes:Envelope>
+"#;
+    let (date, raw) = parse_ecb_xml(SELF_CLOSING_DATE_XML).unwrap();
+    assert_eq!(date, NaiveDate::from_ymd_opt(2026, 7, 21).unwrap());
+    // The empty block carries no rows of its own; the real block's row survives.
+    assert_eq!(raw.len(), 1);
+    assert_eq!(raw[0].0, "USD");
+}
+
+#[test]
+fn an_unrecognised_cube_attribute_is_ignored() {
+    // ECB has added attributes to this feed before. An unknown one must be passed
+    // over rather than derailing the attribute scan, so a feed extension does not
+    // turn into a parse failure that blocks every FX post.
+    const EXTRA_ATTRIBUTE_XML: &[u8] = br#"<?xml version="1.0" encoding="UTF-8"?>
+<gesmes:Envelope xmlns:gesmes="http://www.gesmes.org/xml/2002-08-01" xmlns="http://www.ecb.int/vocabulary/2002-08-01/eurofxref">
+  <Cube>
+    <Cube time="2026-07-21" source="ecb">
+      <Cube currency="USD" rate="1.0856" revision="2"/>
+    </Cube>
+  </Cube>
+</gesmes:Envelope>
+"#;
+    let (date, raw) = parse_ecb_xml(EXTRA_ATTRIBUTE_XML).unwrap();
+    assert_eq!(date, NaiveDate::from_ymd_opt(2026, 7, 21).unwrap());
+    assert_eq!(raw.len(), 1);
+    assert_eq!(raw[0], ("USD".to_owned(), "1.0856".to_owned()));
+}
+
+#[test]
+fn non_iso4217_shaped_currency_is_dropped_not_stored() {
+    // The feed is a system boundary: a compromised/misconfigured upstream must
+    // not get an arbitrary string into a tenant's FX store as a currency code.
+    const INJECTED_XML: &[u8] = br#"<?xml version="1.0" encoding="UTF-8"?>
+<gesmes:Envelope xmlns:gesmes="http://www.gesmes.org/xml/2002-08-01" xmlns="http://www.ecb.int/vocabulary/2002-08-01/eurofxref">
+  <Cube>
+    <Cube time="2026-07-21">
+      <Cube currency="USD" rate="1.0856"/>
+      <Cube currency="NOT-A-CURRENCY" rate="1.0"/>
+      <Cube currency="U$D" rate="1.0"/>
+      <Cube currency="" rate="1.0"/>
+    </Cube>
+  </Cube>
+</gesmes:Envelope>
+"#;
+    let (_date, raw) = parse_ecb_xml(INJECTED_XML).unwrap();
+    assert_eq!(raw.len(), 1, "only the well-formed code survives");
+    assert_eq!(raw[0].0, "USD");
+}
+
+#[test]
+fn lowercase_feed_currency_is_normalized_to_uppercase() {
+    // Keeps the stored code canonical so the ledger never holds both "usd" and
+    // "USD" rows for one currency.
+    const LOWERCASE_XML: &[u8] = br#"<?xml version="1.0" encoding="UTF-8"?>
+<gesmes:Envelope xmlns:gesmes="http://www.gesmes.org/xml/2002-08-01" xmlns="http://www.ecb.int/vocabulary/2002-08-01/eurofxref">
+  <Cube>
+    <Cube time="2026-07-21">
+      <Cube currency="usd" rate="1.0856"/>
+    </Cube>
+  </Cube>
+</gesmes:Envelope>
+"#;
+    let (_date, raw) = parse_ecb_xml(LOWERCASE_XML).unwrap();
+    assert_eq!(raw.len(), 1);
+    assert_eq!(raw[0].0, "USD");
+}
+
+#[test]
+fn all_currencies_malformed_yields_no_rate_entries_error() {
+    // Dropping every entry must surface as an error, never a silent empty `Ok`.
+    const ALL_BAD_XML: &[u8] = br#"<?xml version="1.0" encoding="UTF-8"?>
+<gesmes:Envelope xmlns:gesmes="http://www.gesmes.org/xml/2002-08-01" xmlns="http://www.ecb.int/vocabulary/2002-08-01/eurofxref">
+  <Cube>
+    <Cube time="2026-07-21">
+      <Cube currency="BAD-CODE" rate="1.0"/>
+    </Cube>
+  </Cube>
+</gesmes:Envelope>
+"#;
+    assert!(matches!(
+        parse_ecb_xml(ALL_BAD_XML),
+        Err(RateProviderError::Internal(_))
+    ));
+}
+
+#[test]
+fn one_unconvertible_rate_does_not_cost_the_whole_document() {
+    // The ledger's RateSyncJob turns ANY configured-provider failure into
+    // FX_SNAPSHOT_MISSING and refreshes nothing, so failing the batch over a
+    // single bad value would stall the FX fan-out for every other currency.
+    let raw = vec![
+        ("USD".to_owned(), "1.0856".to_owned()),
+        ("JPY".to_owned(), "not-a-number".to_owned()),
+        ("GBP".to_owned(), "0.84".to_owned()),
+    ];
+    let date = NaiveDate::from_ymd_opt(2026, 7, 21).unwrap();
+    let rates = ecb_rates_to_provider_rates(date, &raw, &[], PROVIDER).unwrap();
+    assert_eq!(rates.len(), 2, "the two good entries must still be served");
+    assert!(rates.iter().all(|r| r.quote != "JPY"));
+}
+
+#[test]
+fn a_non_positive_rate_is_skipped_like_any_other_unconvertible_value() {
+    // Zero/negative rates are rejected by the converter (there are none in this
+    // domain); that rejection must be per-entry, not fatal for the batch.
+    let raw = vec![
+        ("USD".to_owned(), "1.0856".to_owned()),
+        ("JPY".to_owned(), "0".to_owned()),
+        ("CHF".to_owned(), "-1.5".to_owned()),
+    ];
+    let date = NaiveDate::from_ymd_opt(2026, 7, 21).unwrap();
+    let rates = ecb_rates_to_provider_rates(date, &raw, &[], PROVIDER).unwrap();
+    assert_eq!(rates.len(), 1);
+    assert_eq!(rates[0].quote, "USD");
+}
+
+#[test]
+fn all_rates_unconvertible_is_internal_error_not_an_empty_ok() {
+    // An empty table passed off as success would read as a served tick and
+    // suppress the composite's fallback.
+    let raw = vec![
+        ("USD".to_owned(), "nope".to_owned()),
+        ("JPY".to_owned(), String::new()),
+    ];
+    let date = NaiveDate::from_ymd_opt(2026, 7, 21).unwrap();
+    assert!(matches!(
+        ecb_rates_to_provider_rates(date, &raw, &[], PROVIDER),
+        Err(RateProviderError::Internal(_))
+    ));
+}
+
+#[test]
+fn pair_filter_excluding_everything_is_pair_unavailable() {
+    // Nothing was *attempted*, so this is "the feed does not publish what you
+    // asked for", not a fault. It stays an `Err` so the composite advances to a
+    // source that might publish the pair.
+    let raw = vec![("USD".to_owned(), "1.0856".to_owned())];
+    let date = NaiveDate::from_ymd_opt(2026, 7, 21).unwrap();
+    let want = vec![CurrencyPair {
+        base: "EUR".to_owned(),
+        quote: "CHF".to_owned(),
+    }];
+    let err = ecb_rates_to_provider_rates(date, &raw, &want, PROVIDER).unwrap_err();
+    assert!(
+        matches!(&err, RateProviderError::PairUnavailable { base, quote } if base == "EUR" && quote == "CHF"),
+        "expected PairUnavailable naming the requested pair, got {err:?}"
+    );
+}
+
+#[test]
+fn no_requested_pairs_and_an_empty_feed_stays_ok() {
+    // The whole-table call the ledger actually makes: with `pairs` empty there is
+    // no pair to report as unavailable, so an empty feed is a served document
+    // with nothing in it, not an error.
+    let date = NaiveDate::from_ymd_opt(2026, 7, 21).unwrap();
+    let rates = ecb_rates_to_provider_rates(date, &[], &[], PROVIDER).unwrap();
+    assert!(rates.is_empty());
+}
+
+#[test]
+fn cube_with_only_one_of_currency_or_rate_is_ignored() {
+    // A truncated/malformed feed row: unusable, and must not be recorded.
+    const HALF_PAIR_XML: &[u8] = br#"<?xml version="1.0" encoding="UTF-8"?>
+<gesmes:Envelope xmlns:gesmes="http://www.gesmes.org/xml/2002-08-01" xmlns="http://www.ecb.int/vocabulary/2002-08-01/eurofxref">
+  <Cube>
+    <Cube time="2026-07-21">
+      <Cube currency="USD" rate="1.0856"/>
+      <Cube currency="JPY"/>
+      <Cube rate="160.85"/>
+    </Cube>
+  </Cube>
+</gesmes:Envelope>
+"#;
+    let (_date, raw) = parse_ecb_xml(HALF_PAIR_XML).unwrap();
+    assert_eq!(raw.len(), 1, "only the complete entry survives");
+    assert_eq!(raw[0].0, "USD");
+}
+
+#[test]
+fn currency_row_after_the_date_block_closes_is_omitted() {
+    // GBP is a SIBLING of the date Cube, not nested inside it, so it was never
+    // published under 2026-07-21. Comparing dates alone cannot catch this, because
+    // `current_date` outlives the element it came from.
+    const SIBLING_AFTER_BLOCK_XML: &[u8] = br#"<?xml version="1.0" encoding="UTF-8"?>
+<gesmes:Envelope xmlns:gesmes="http://www.gesmes.org/xml/2002-08-01" xmlns="http://www.ecb.int/vocabulary/2002-08-01/eurofxref">
+  <Cube>
+    <Cube time="2026-07-21">
+      <Cube currency="USD" rate="1.0856"/>
+    </Cube>
+    <Cube currency="GBP" rate="0.8600"/>
+  </Cube>
+</gesmes:Envelope>
+"#;
+    let (date, raw) = parse_ecb_xml(SIBLING_AFTER_BLOCK_XML).unwrap();
+    assert_eq!(date, NaiveDate::from_ymd_opt(2026, 7, 21).unwrap());
+    assert_eq!(raw.len(), 1, "the out-of-block row must not be recorded");
+    assert_eq!(raw[0].0, "USD");
+}
+
+#[test]
+fn rows_under_an_undated_inner_block_are_omitted() {
+    // GBP sits inside a Cube whose own `time` is unparseable, which is itself
+    // still inside the dated block, so the depth check alone would keep it and
+    // stamp 2026-07-21 onto a rate whose real publication date is unknown. Only
+    // the "does this row's block carry the document's date?" check catches it.
+    const UNDATED_INNER_XML: &[u8] = br#"<?xml version="1.0" encoding="UTF-8"?>
+<gesmes:Envelope xmlns:gesmes="http://www.gesmes.org/xml/2002-08-01" xmlns="http://www.ecb.int/vocabulary/2002-08-01/eurofxref">
+  <Cube>
+    <Cube time="2026-07-21">
+      <Cube currency="USD" rate="1.0856"/>
+      <Cube time="21-07-2026">
+        <Cube currency="GBP" rate="0.8600"/>
+      </Cube>
+    </Cube>
+  </Cube>
+</gesmes:Envelope>
+"#;
+    let (date, raw) = parse_ecb_xml(UNDATED_INNER_XML).unwrap();
+    assert_eq!(date, NaiveDate::from_ymd_opt(2026, 7, 21).unwrap());
+    assert_eq!(raw.len(), 1, "only the dated block's own rows survive");
+    assert_eq!(raw[0].0, "USD");
+}
+
+#[test]
+fn unparseable_publication_date_is_reported_as_missing_not_silently_ignored() {
+    // The only date in the feed is malformed, so parsing fails; the raw value is
+    // logged (see `update_publication_date`).
+    const BAD_DATE_XML: &[u8] = br#"<?xml version="1.0" encoding="UTF-8"?>
+<gesmes:Envelope xmlns:gesmes="http://www.gesmes.org/xml/2002-08-01" xmlns="http://www.ecb.int/vocabulary/2002-08-01/eurofxref">
+  <Cube>
+    <Cube time="21-07-2026">
+      <Cube currency="USD" rate="1.0856"/>
+    </Cube>
+  </Cube>
+</gesmes:Envelope>
+"#;
+    assert!(matches!(
+        parse_ecb_xml(BAD_DATE_XML),
+        Err(RateProviderError::Internal(_))
+    ));
+}

--- a/gears/bss/rate-provider/plugins/ecb-plugin/src/lib.rs
+++ b/gears/bss/rate-provider/plugins/ecb-plugin/src/lib.rs
@@ -1,0 +1,14 @@
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+//! `bss-rate-provider-ecb-plugin` — the ECB source plugin.
+//!
+//! Fetches the ECB daily reference-rate feed, parses the EUR-based direct pairs,
+//! and registers itself as a [`bss_ledger_sdk::RateProviderV1`] source plugin: a
+//! `PluginV1<RateProviderSourcePluginSpecV1>` instance in the types-registry plus
+//! a scoped `ClientHub` entry keyed by its GTS instance id. The core
+//! `bss-rate-provider` gear discovers it and composes it with any other sources.
+
+pub mod config;
+pub mod gear;
+pub mod infra;
+
+pub use gear::EcbRateProviderPlugin;

--- a/gears/bss/rate-provider/plugins/ecb-plugin/tests/ecb_integration.rs
+++ b/gears/bss/rate-provider/plugins/ecb-plugin/tests/ecb_integration.rs
@@ -1,0 +1,179 @@
+//! Integration: `EcbRateProvider` end-to-end over a local axum server serving
+//! the ECB daily-XML fixture. Covers the HTTP path the unit tests skip.
+#![allow(
+    clippy::unwrap_used,
+    reason = "integration-test setup helpers: an unwrap here just fails the test"
+)]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::Router;
+use axum::http::StatusCode;
+use axum::routing::get;
+use bss_ledger_sdk::{CurrencyPair, RateProviderError, RateProviderV1};
+use bss_rate_provider_ecb_plugin::infra::source::EcbRateProvider;
+use bss_rate_provider_sdk::metrics::NoopFetchMetrics;
+use toolkit_http::HttpClient;
+use toolkit_security::SecurityContext;
+
+const FIXTURE: &str = include_str!("fixtures/eurofxref-daily.xml");
+
+/// The same document dated far enough ahead that no plausible clock skew could
+/// explain it. A fixed year rather than `now() + n` keeps the fixture a
+/// `&'static str`, and it stays "the future" for as long as this code exists.
+const FUTURE_DATED: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<gesmes:Envelope xmlns:gesmes="http://www.gesmes.org/xml/2002-08-01" xmlns="http://www.ecb.int/vocabulary/2002-08-01/eurofxref">
+  <Cube>
+    <Cube time="9999-12-31">
+      <Cube currency="USD" rate="1.0856"/>
+    </Cube>
+  </Cube>
+</gesmes:Envelope>"#;
+
+/// Spawns the fake ECB server and returns its URL plus the server task's
+/// `JoinHandle`. Keeping the handle is the only way to observe the mock server
+/// panicking, instead of the test hanging or failing on a confusing connection
+/// error.
+async fn spawn_server(body: &'static str, status: u16) -> (String, tokio::task::JoinHandle<()>) {
+    let app = Router::new().route(
+        "/eurofxref-daily.xml",
+        get(move || async move { (StatusCode::from_u16(status).unwrap(), body) }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    (format!("http://{addr}/eurofxref-daily.xml"), handle)
+}
+
+fn provider(url: String) -> EcbRateProvider {
+    // Loopback is plain HTTP; a non-FIPS test client allows insecure http.
+    let client = HttpClient::builder()
+        .timeout(Duration::from_secs(2))
+        .build()
+        .unwrap();
+    EcbRateProvider::new("ecb".to_owned(), url, client, Arc::new(NoopFetchMetrics))
+}
+
+#[tokio::test]
+async fn full_fetch_returns_whole_table() {
+    let (url, _server) = spawn_server(FIXTURE, 200).await;
+    let p = provider(url);
+    let ctx = SecurityContext::anonymous();
+    let rates = p.fetch_latest(&ctx, &[], "req").await.unwrap();
+    assert_eq!(rates.len(), 3);
+}
+
+#[tokio::test]
+async fn specific_pair_filter() {
+    let (url, _server) = spawn_server(FIXTURE, 200).await;
+    let p = provider(url);
+    let ctx = SecurityContext::anonymous();
+    let want = vec![CurrencyPair {
+        base: "EUR".to_owned(),
+        quote: "USD".to_owned(),
+    }];
+    let rates = p.fetch_latest(&ctx, &want, "req").await.unwrap();
+    assert_eq!(rates.len(), 1);
+    assert_eq!(rates[0].quote, "USD");
+}
+
+#[tokio::test]
+async fn upstream_503_maps_to_upstream_status() {
+    let (url, _server) = spawn_server(FIXTURE, 503).await;
+    let p = provider(url);
+    let ctx = SecurityContext::anonymous();
+    let err = p.fetch_latest(&ctx, &[], "req").await.unwrap_err();
+    assert!(matches!(err, RateProviderError::UpstreamStatus(503)));
+}
+
+#[tokio::test]
+async fn health_probe_succeeds_on_200() {
+    let (url, _server) = spawn_server(FIXTURE, 200).await;
+    let p = provider(url);
+    let ctx = SecurityContext::anonymous();
+    p.health(&ctx, "req").await.unwrap();
+}
+
+#[tokio::test]
+async fn health_probe_passes_on_a_non_success_status() {
+    // The probe answers "did anything get through", and a 503 proves it did — the
+    // status is logged, not returned as a failure. Reading a non-2xx as unhealthy
+    // would also report a working feed as down on any endpoint that replies 405 to
+    // HEAD while serving GET.
+    for status in [403, 404, 405, 500, 503] {
+        let (url, _server) = spawn_server(FIXTURE, status).await;
+        let p = provider(url);
+        let ctx = SecurityContext::anonymous();
+        assert!(
+            p.health(&ctx, "req").await.is_ok(),
+            "{status} is the host answering, so the probe must pass"
+        );
+    }
+}
+
+#[tokio::test]
+async fn health_probe_fails_only_when_nothing_gets_through() {
+    // The other side of the bound above: with no listener the request dies at the
+    // transport level, the one genuinely unreachable case.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    drop(listener);
+
+    let p = provider(format!("http://{addr}/eurofxref-daily.xml"));
+    let ctx = SecurityContext::anonymous();
+    let err = p.health(&ctx, "req").await.unwrap_err();
+    assert!(
+        matches!(err, RateProviderError::Unreachable(_)),
+        "a transport failure must be Unreachable, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn a_future_dated_document_is_rejected_rather_than_served() {
+    // A future `as_of` has a negative age, so the ledger's age-based staleness
+    // rule would read it as fresh forever. It must fail the fetch instead, which
+    // also lets the composite fall through to the next source.
+    let (url, _server) = spawn_server(FUTURE_DATED, 200).await;
+    let p = provider(url);
+    let ctx = SecurityContext::anonymous();
+    let err = p.fetch_latest(&ctx, &[], "req").await.unwrap_err();
+    assert!(
+        matches!(err, RateProviderError::Internal(ref m) if m.contains("9999-12-31")),
+        "expected the rejection to name the offending publication time, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn connection_refused_maps_to_unreachable() {
+    // Bind then immediately drop the listener: the port is free but nothing is
+    // listening, so the request fails at the transport level.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    drop(listener);
+
+    let p = provider(format!("http://{addr}/eurofxref-daily.xml"));
+    let ctx = SecurityContext::anonymous();
+    let err = p.fetch_latest(&ctx, &[], "req").await.unwrap_err();
+    assert!(matches!(err, RateProviderError::Unreachable(_)));
+}
+
+#[tokio::test]
+async fn provider_id_reports_the_configured_id_not_a_hardcoded_one() {
+    // The composite reads this to attribute its logs, and the id also has to
+    // survive into every rate as provenance. Returning a constant baked into the
+    // source instead of the configured value would make two ECB-family feeds
+    // indistinguishable in the ledger's stored rows.
+    let (url, _server) = spawn_server(FIXTURE, 200).await;
+    let p = provider(url);
+    assert_eq!(p.provider_id(), "ecb");
+
+    let ctx = SecurityContext::anonymous();
+    let rates = p.fetch_latest(&ctx, &[], "req").await.unwrap();
+    assert!(
+        rates.iter().all(|r| r.provider == p.provider_id()),
+        "every served rate must carry the same id the source reports"
+    );
+}

--- a/gears/bss/rate-provider/plugins/ecb-plugin/tests/fixtures/eurofxref-daily.xml
+++ b/gears/bss/rate-provider/plugins/ecb-plugin/tests/fixtures/eurofxref-daily.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gesmes:Envelope xmlns:gesmes="http://www.gesmes.org/xml/2002-08-01" xmlns="http://www.ecb.int/vocabulary/2002-08-01/eurofxref">
+  <gesmes:subject>Reference rates</gesmes:subject>
+  <gesmes:Sender><gesmes:name>European Central Bank</gesmes:name></gesmes:Sender>
+  <Cube>
+    <Cube time="2026-07-21">
+      <Cube currency="USD" rate="1.0856"/>
+      <Cube currency="JPY" rate="160.85"/>
+      <Cube currency="GBP" rate="0.8571"/>
+    </Cube>
+  </Cube>
+</gesmes:Envelope>

--- a/gears/bss/rate-provider/plugins/http-json-plugin/Cargo.toml
+++ b/gears/bss/rate-provider/plugins/http-json-plugin/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+name = "bss-rate-provider-http-json-plugin"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+description = "BSS FX rate-provider generic http-json source plugin: config-mapped GET-JSON feed registered as a RateProviderV1 plugin instance"
+
+[lints]
+workspace = true
+
+[dependencies]
+bss-rate-provider-sdk = { workspace = true }
+bss-ledger-sdk = { workspace = true }
+# The `deps = [types_registry]` gear-macro edge re-exports `::types_registry`, so
+# the gear crate must be a direct dependency (init-ordering; not used in code).
+types-registry = { workspace = true }
+toolkit = { workspace = true }
+toolkit-security = { workspace = true }
+toolkit-http = { workspace = true, features = ["otel"] }
+inventory = { workspace = true }
+
+async-trait = { workspace = true }
+anyhow = { workspace = true }
+tracing = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+# DateTime<Utc> parse for the publication timestamp; no `clock` feature.
+chrono = { workspace = true }
+# `SecretString` for `api_key`: redacts on Debug/log, matches the
+# authn-resolver convention for optional secret config fields.
+secrecy = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }
+# In-process HTTP server for the integration test.
+axum = { workspace = true }
+# `GearCtx::new` arguments for the `init()` test in gear.rs: the process
+# instance id and the root cancellation token.
+uuid = { workspace = true }
+tokio-util = { workspace = true }
+# Parses the YAML config fixtures in config_tests.rs (the repo's YAML crate).
+serde-saphyr = { workspace = true }
+# Scoped env-var mutation for the `${VAR}`-expansion tests in config_tests.rs.
+temp-env = { workspace = true }

--- a/gears/bss/rate-provider/plugins/http-json-plugin/src/config.rs
+++ b/gears/bss/rate-provider/plugins/http-json-plugin/src/config.rs
@@ -1,0 +1,129 @@
+//! http-json source-plugin configuration.
+
+use secrecy::SecretString;
+use serde::Deserialize;
+use toolkit::var_expand::{ExpandVars, ExpandVarsError};
+
+/// Config for the generic http-json source plugin.
+#[derive(Debug, Clone, Deserialize, toolkit::ExpandVars)]
+#[serde(default, deny_unknown_fields)]
+pub struct HttpJsonPluginConfig {
+    /// Stable `provider_id` stamped on synced ledger rows.
+    pub id: String,
+    /// Plugin-selection vendor (must match the core gear's configured vendor).
+    pub vendor: String,
+    /// Fallback order: lower `priority` is tried first by the composite.
+    pub priority: i16,
+    /// Feed endpoint (MUST be https; required — no sensible default).
+    pub base_url: String,
+    /// Outbound per-attempt HTTP timeout in milliseconds.
+    pub timeout_ms: u64,
+    /// How the feed is authenticated, and the credential it needs (if any).
+    ///
+    /// Marked for `${VAR}` expansion so the credential can be kept out of the
+    /// config file itself — see [`Auth`]'s [`ExpandVars`] impl.
+    #[expand_vars]
+    pub auth: Auth,
+    /// Field mapping (required for this kind).
+    pub mapping: Option<Mapping>,
+}
+
+impl Default for HttpJsonPluginConfig {
+    fn default() -> Self {
+        Self {
+            id: "http-json".to_owned(),
+            vendor: "cf.bss".to_owned(),
+            priority: 200,
+            base_url: String::new(),
+            timeout_ms: 5000,
+            auth: Auth::None {},
+            mapping: None,
+        }
+    }
+}
+
+/// How the feed is authenticated — the credential is carried by the variant that
+/// needs it, so an unusable combination cannot be configured in the first place.
+///
+/// Both bad combinations — a kind that needs a key with no key set, and a key
+/// attached to `none` — are `serde` errors at config load, not runtime checks:
+/// invalid states are unrepresentable rather than validated.
+///
+/// YAML shape (omit `auth:` entirely for the no-credential case):
+///
+/// ```yaml
+/// auth:
+///   kind: bearer          # none | bearer | header-key
+///   api_key: "${BANK_X_KEY}"
+/// ```
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case", deny_unknown_fields)]
+pub enum Auth {
+    /// No credential is sent (a public feed like ECB's).
+    ///
+    /// An empty struct variant rather than a unit one: `deny_unknown_fields` is not
+    /// enforced for unit variants of an internally-tagged enum, so `kind: none`
+    /// with a stray `api_key` beside it would parse and then silently send
+    /// unauthenticated requests. As `None {}` the stray field is rejected.
+    None {},
+    /// `Authorization: Bearer <api_key>`.
+    Bearer {
+        /// `${VAR}` placeholders are expanded from the environment at `init()`
+        /// (see [`Auth`]'s [`ExpandVars`] impl); `SecretString` keeps the value
+        /// out of `Debug` and any accidental log line.
+        api_key: SecretString,
+    },
+    /// A custom header carrying the key (header name fixed to `X-API-Key` in v1).
+    HeaderKey {
+        /// See [`Auth::Bearer::api_key`].
+        api_key: SecretString,
+    },
+}
+
+/// Field mapping for the http-json source (simple dotted paths, design O-11 scope).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Mapping {
+    /// Base currency: a literal (single-base feed, e.g. "USD") — v1 supports literal only.
+    pub base: String,
+    /// Dotted path to the object of quote -> entry (e.g. "rates").
+    pub rates: String,
+    /// Field name of the numeric rate within each entry (e.g. "value").
+    pub rate: String,
+    /// Dotted path to the publication timestamp (e.g. "date").
+    pub as_of: String,
+}
+
+/// Expands `${VAR}` placeholders in the credential the variant carries.
+///
+/// Hand-written because `#[derive(ExpandVars)]` only supports structs with named
+/// fields, while the credential deliberately lives inside an enum variant. Without
+/// this, `api_key: "${BANK_X_KEY}"` would be sent to the feed as that literal
+/// string, leaving the raw key in the config file as the only working option —
+/// and `toolkit`'s effective-config dump serializes the config file *before*
+/// typed deserialization, so a hardcoded key is disclosed verbatim by a routine
+/// diagnostic while a placeholder is not (DESIGN §2.2 "Secrets handling").
+///
+/// A missing variable is an error, never a silent fallback: `init()` fails loudly
+/// rather than the source authenticating with a placeholder.
+impl ExpandVars for Auth {
+    fn expand_vars(&mut self) -> Result<(), ExpandVarsError> {
+        match self {
+            Self::None {} => Ok(()),
+            Self::Bearer { api_key } | Self::HeaderKey { api_key } => api_key.expand_vars(),
+        }
+    }
+}
+
+impl Default for Auth {
+    /// A public, unauthenticated feed — hand-written because `#[derive(Default)]`
+    /// only accepts a unit variant as the default, and the no-credential variant
+    /// is deliberately an empty struct variant (see its docs).
+    fn default() -> Self {
+        Self::None {}
+    }
+}
+
+#[cfg(test)]
+#[path = "config_tests.rs"]
+mod tests;

--- a/gears/bss/rate-provider/plugins/http-json-plugin/src/config_tests.rs
+++ b/gears/bss/rate-provider/plugins/http-json-plugin/src/config_tests.rs
@@ -1,0 +1,151 @@
+//! Config-deserialization tests — the auth enum's job is to make an unusable
+//! credential combination impossible to express, so these assert the parse
+//! outcome rather than a downstream runtime check.
+
+use secrecy::ExposeSecret;
+use toolkit::var_expand::ExpandVars;
+
+use super::{Auth, HttpJsonPluginConfig};
+
+#[test]
+fn omitted_auth_defaults_to_none() {
+    let cfg: HttpJsonPluginConfig = serde_saphyr::from_str("id: bank-x").unwrap();
+    assert!(matches!(cfg.auth, Auth::None {}));
+}
+
+#[test]
+fn bearer_carries_its_key() {
+    let cfg: HttpJsonPluginConfig =
+        serde_saphyr::from_str("auth:\n  kind: bearer\n  api_key: secret-key\n").unwrap();
+    match cfg.auth {
+        Auth::Bearer { api_key } => assert_eq!(api_key.expose_secret(), "secret-key"),
+        other => panic!("expected Bearer, got {other:?}"),
+    }
+}
+
+#[test]
+fn header_key_carries_its_key() {
+    let cfg: HttpJsonPluginConfig =
+        serde_saphyr::from_str("auth:\n  kind: header-key\n  api_key: secret-key\n").unwrap();
+    match cfg.auth {
+        Auth::HeaderKey { api_key } => assert_eq!(api_key.expose_secret(), "secret-key"),
+        other => panic!("expected HeaderKey, got {other:?}"),
+    }
+}
+
+#[test]
+fn a_kind_that_needs_a_key_cannot_be_configured_without_one() {
+    // Asserting rejection (not the message text) keeps the test off the YAML
+    // parser's error formatting.
+    assert!(
+        serde_saphyr::from_str::<HttpJsonPluginConfig>("auth:\n  kind: bearer\n").is_err(),
+        "bearer without api_key must be rejected at config load"
+    );
+}
+
+#[test]
+fn a_key_cannot_be_attached_to_the_no_auth_kind() {
+    // A key attached to `none` would be silently ignored and every request
+    // would go out unauthenticated, so the config must be rejected outright.
+    assert!(
+        serde_saphyr::from_str::<HttpJsonPluginConfig>("auth:\n  kind: none\n  api_key: k\n")
+            .is_err(),
+        "a credential attached to the no-auth kind must be rejected"
+    );
+}
+
+#[test]
+fn unknown_auth_kind_is_rejected() {
+    assert!(serde_saphyr::from_str::<HttpJsonPluginConfig>("auth:\n  kind: mtls\n").is_err());
+}
+
+#[test]
+fn stray_top_level_api_key_is_rejected() {
+    // `api_key` lives inside `auth`; a stray top-level one must fail loudly
+    // rather than silently authenticating with nothing.
+    assert!(serde_saphyr::from_str::<HttpJsonPluginConfig>("api_key: leftover\n").is_err());
+}
+
+#[test]
+fn a_bearer_key_is_expanded_from_the_environment() {
+    // A `${VAR}` placeholder keeps the raw key out of the config file, which the
+    // effective-config dump serializes verbatim. Without expansion the feed would
+    // receive the literal "${...}" string as its credential.
+    temp_env::with_vars(
+        [("RATE_PROVIDER_TEST_BEARER_KEY", Some("live-bearer"))],
+        || {
+            let mut cfg: HttpJsonPluginConfig = serde_saphyr::from_str(
+                "auth:\n  kind: bearer\n  api_key: \"${RATE_PROVIDER_TEST_BEARER_KEY}\"\n",
+            )
+            .unwrap();
+            cfg.expand_vars().unwrap();
+            match cfg.auth {
+                Auth::Bearer { api_key } => assert_eq!(api_key.expose_secret(), "live-bearer"),
+                other => panic!("expected Bearer, got {other:?}"),
+            }
+        },
+    );
+}
+
+#[test]
+fn a_header_key_is_expanded_from_the_environment() {
+    temp_env::with_vars(
+        [("RATE_PROVIDER_TEST_HEADER_KEY", Some("live-header"))],
+        || {
+            let mut cfg: HttpJsonPluginConfig = serde_saphyr::from_str(
+                "auth:\n  kind: header-key\n  api_key: \"${RATE_PROVIDER_TEST_HEADER_KEY}\"\n",
+            )
+            .unwrap();
+            cfg.expand_vars().unwrap();
+            match cfg.auth {
+                Auth::HeaderKey { api_key } => assert_eq!(api_key.expose_secret(), "live-header"),
+                other => panic!("expected HeaderKey, got {other:?}"),
+            }
+        },
+    );
+}
+
+#[test]
+fn an_unresolvable_placeholder_is_an_error_not_a_literal_credential() {
+    // Authenticating with a literal "${MISSING}" would fail against the feed in a
+    // way that looks like an upstream problem. `init()` must abort instead.
+    temp_env::with_vars([("RATE_PROVIDER_TEST_ABSENT_KEY", None::<&str>)], || {
+        let mut cfg: HttpJsonPluginConfig = serde_saphyr::from_str(
+            "auth:\n  kind: bearer\n  api_key: \"${RATE_PROVIDER_TEST_ABSENT_KEY}\"\n",
+        )
+        .unwrap();
+        assert!(cfg.expand_vars().is_err());
+    });
+}
+
+#[test]
+fn a_no_credential_config_survives_the_expansion_pass() {
+    // The expansion pass runs over every config, not only the ones carrying a
+    // credential. A `None` arm that errored (or panicked) would break the ECB-style
+    // public-feed case, which is the only configuration v1 actually ships.
+    let mut cfg: HttpJsonPluginConfig = serde_saphyr::from_str("id: public-feed").unwrap();
+    cfg.expand_vars().unwrap();
+    assert!(matches!(cfg.auth, Auth::None {}));
+}
+
+#[test]
+fn the_auth_default_is_the_no_credential_variant() {
+    // Hand-written rather than derived, because `#[derive(Default)]` only accepts
+    // a unit variant and the no-credential case is deliberately an empty struct
+    // variant. A wrong default here would send a credential-bearing header shape
+    // for a feed that has no credential.
+    assert!(matches!(Auth::default(), Auth::None {}));
+}
+
+#[test]
+fn a_literal_key_survives_expansion_unchanged() {
+    // A key written straight into the config file (discouraged, but valid) must
+    // not be mangled by the expansion pass.
+    let mut cfg: HttpJsonPluginConfig =
+        serde_saphyr::from_str("auth:\n  kind: bearer\n  api_key: plain-key\n").unwrap();
+    cfg.expand_vars().unwrap();
+    match cfg.auth {
+        Auth::Bearer { api_key } => assert_eq!(api_key.expose_secret(), "plain-key"),
+        other => panic!("expected Bearer, got {other:?}"),
+    }
+}

--- a/gears/bss/rate-provider/plugins/http-json-plugin/src/gear.rs
+++ b/gears/bss/rate-provider/plugins/http-json-plugin/src/gear.rs
@@ -1,0 +1,174 @@
+//! http-json source-plugin gear: build the source, register a `PluginV1`
+//! instance in the types-registry, and register the scoped `RateProviderV1`
+//! client keyed by the GTS instance id.
+
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use bss_ledger_sdk::RateProviderV1;
+use bss_rate_provider_sdk::RateProviderSourcePluginSpecV1;
+use bss_rate_provider_sdk::http_client::build_source_http_client;
+use bss_rate_provider_sdk::metrics::{OtelFetchMetrics, SharedFetchMetrics};
+use bss_rate_provider_sdk::registration::register_rate_provider_plugin;
+use toolkit::Gear;
+use toolkit::config::ConfigError;
+use toolkit::context::GearCtx;
+use tracing::info;
+
+use crate::config::HttpJsonPluginConfig;
+use crate::infra::source::{HttpJsonRateProvider, HttpJsonSourceSettings};
+
+/// Stable GTS instance segment appended to the source-plugin type id. Must be a
+/// single valid GTS segment (`vendor.name.plugin.vN`, 5 dot-components).
+const INSTANCE_SEGMENT: &str = "cf.bss.rate_provider_http_json.plugin.v1";
+
+/// The http-json source-plugin gear.
+#[toolkit::gear(name = "bss-rate-provider-http-json-plugin", deps = [types_registry])]
+pub struct HttpJsonRateProviderPlugin;
+
+impl Default for HttpJsonRateProviderPlugin {
+    fn default() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl Gear for HttpJsonRateProviderPlugin {
+    async fn init(&self, ctx: &GearCtx) -> Result<()> {
+        // Config gate: absent => inert; present-but-empty => defaults (which lack
+        // a usable base_url/mapping and are rejected below); invalid => abort.
+        //
+        // `config_expanded` (not `config`) so a `${VAR}` credential is resolved
+        // from the environment here — that is what lets the raw key stay out of
+        // the config file. An unresolvable variable lands in the catch-all arm
+        // below and aborts init, rather than the source coming up and sending the
+        // literal placeholder as its credential.
+        let cfg: HttpJsonPluginConfig = match ctx.config_expanded::<HttpJsonPluginConfig>() {
+            Ok(cfg) => cfg,
+            Err(ConfigError::MissingConfigSection { .. }) => HttpJsonPluginConfig::default(),
+            Err(ConfigError::GearNotFound { .. }) => {
+                info!("bss-rate-provider-http-json-plugin: not configured; skipping registration");
+                return Ok(());
+            }
+            Err(e) => return Err(e).context("bss-rate-provider-http-json-plugin: invalid config"),
+        };
+
+        // Required, source-specific config: a field mapping and an https endpoint.
+        // (An auth kind that needs a credential without one is impossible to
+        // express — `config::Auth` carries the key in the variant, so serde
+        // rejects it at config load; no runtime check belongs here.)
+        let mapping = cfg.mapping.clone().ok_or_else(|| {
+            anyhow::anyhow!("bss-rate-provider-http-json-plugin: `mapping` is required")
+        })?;
+
+        let client = build_source_http_client(&cfg.base_url, cfg.timeout_ms)
+            .context("bss-rate-provider-http-json-plugin: build HTTP client")?;
+        let metrics: SharedFetchMetrics = Arc::new(OtelFetchMetrics::from_global());
+        let source: Arc<dyn RateProviderV1> = Arc::new(HttpJsonRateProvider::new(
+            HttpJsonSourceSettings {
+                id: cfg.id.clone(),
+                base_url: cfg.base_url.clone(),
+                auth: cfg.auth.clone(),
+                mapping,
+            },
+            client,
+            metrics,
+        ));
+
+        let instance_id = register_rate_provider_plugin::<RateProviderSourcePluginSpecV1>(
+            ctx,
+            INSTANCE_SEGMENT,
+            cfg.vendor.clone(),
+            cfg.priority,
+            source,
+        )
+        .await?;
+
+        info!(
+            provider = %cfg.id,
+            instance_id = %instance_id,
+            priority = cfg.priority,
+            "bss-rate-provider-http-json-plugin: registered http-json source plugin"
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod gts_id_tests {
+    use bss_rate_provider_sdk::RateProviderSourcePluginSpecV1;
+    use bss_rate_provider_sdk::registration::assert_registration_builds_valid_gts_id;
+
+    /// The built plugin instance id must parse as a valid GTS id.
+    #[test]
+    fn instance_id_parses_as_gts() {
+        assert_registration_builds_valid_gts_id::<RateProviderSourcePluginSpecV1>(
+            super::INSTANCE_SEGMENT,
+            "cf.bss",
+            200,
+        );
+    }
+}
+
+#[cfg(test)]
+mod init_tests {
+    use std::sync::Arc;
+
+    use tokio_util::sync::CancellationToken;
+    use toolkit::config::ConfigProvider;
+    use toolkit::{ClientHub, Gear, GearCtx};
+    use uuid::Uuid;
+
+    use super::HttpJsonRateProviderPlugin;
+
+    /// Serves one fixed gear-config JSON tree — the same minimal
+    /// `ConfigProvider` shape peer gears use for `init()` tests (e.g.
+    /// event-broker's `module_tests.rs`).
+    struct StaticConfigProvider {
+        root: serde_json::Value,
+    }
+
+    impl ConfigProvider for StaticConfigProvider {
+        fn get_gear_config(&self, gear: &str) -> Option<&serde_json::Value> {
+            self.root.get(gear)
+        }
+    }
+
+    /// `mapping` is required for this plugin: a configured feed with no field
+    /// mapping can map no document, so `init()` must abort loudly rather than
+    /// register a source that fails on every fetch. The config here is
+    /// otherwise valid (an https `base_url`), so the only thing that can fail
+    /// is the `mapping` check — and the error must name the field. The auth
+    /// half of the old runtime validation is covered at the config-parse level
+    /// in `config_tests.rs` (invalid combinations are unrepresentable).
+    #[tokio::test]
+    async fn init_without_mapping_fails_naming_the_field() {
+        let root = serde_json::json!({
+            "bss-rate-provider-http-json-plugin": {
+                "config": {
+                    "id": "bank-x",
+                    "vendor": "cf.bss",
+                    "priority": 210,
+                    "base_url": "https://feed.example/rates",
+                }
+            }
+        });
+        let ctx = GearCtx::new(
+            HttpJsonRateProviderPlugin::MODULE_NAME,
+            Uuid::nil(),
+            Arc::new(StaticConfigProvider { root }),
+            Arc::new(ClientHub::new()),
+            CancellationToken::new(),
+        );
+
+        let err = HttpJsonRateProviderPlugin
+            .init(&ctx)
+            .await
+            .expect_err("a present config without `mapping` must abort init");
+        assert!(
+            err.to_string().contains("mapping"),
+            "the error must name the missing field, got: {err}"
+        );
+    }
+}

--- a/gears/bss/rate-provider/plugins/http-json-plugin/src/infra/mod.rs
+++ b/gears/bss/rate-provider/plugins/http-json-plugin/src/infra/mod.rs
@@ -1,0 +1,4 @@
+//! Infrastructure layer — the outbound GET-JSON feed adapter (HTTP fetch +
+//! configured field mapping) behind the ledger's `RateProviderV1` contract.
+
+pub mod source;

--- a/gears/bss/rate-provider/plugins/http-json-plugin/src/infra/source.rs
+++ b/gears/bss/rate-provider/plugins/http-json-plugin/src/infra/source.rs
@@ -1,0 +1,322 @@
+//! `HttpJsonRateProvider` — config-driven GET-JSON fetch + field mapping. Direct
+//! pairs only — a requested pair whose base is not the feed base is omitted.
+
+use std::borrow::Cow;
+
+use async_trait::async_trait;
+use bss_ledger_sdk::{CurrencyPair, ProviderRate, RateProviderError, RateProviderV1};
+use bss_rate_provider_sdk::conversion::rate_to_micro;
+use bss_rate_provider_sdk::currency::normalize_currency;
+use bss_rate_provider_sdk::error::map_http_error;
+use bss_rate_provider_sdk::fetch::fetch_and_parse;
+use bss_rate_provider_sdk::metrics::SharedFetchMetrics;
+use bss_rate_provider_sdk::publication_time::reject_future_publication_time;
+use chrono::{DateTime, Utc};
+use secrecy::ExposeSecret;
+use serde_json::Value;
+use toolkit_http::{HttpClient, RequestBuilder};
+use toolkit_security::SecurityContext;
+
+use crate::config::{Auth, Mapping};
+
+/// Custom header used for [`Auth::HeaderKey`].
+const API_KEY_HEADER: &str = "X-API-Key";
+
+/// Walk a dotted path (`a.b.c`) through nested JSON objects.
+#[must_use]
+pub fn json_lookup<'a>(value: &'a Value, dotted: &str) -> Option<&'a Value> {
+    let mut current = value;
+    for segment in dotted.split('.') {
+        current = current.get(segment)?;
+    }
+    Some(current)
+}
+
+/// Apply the mapping to a parsed JSON document, stamping `provider` onto every
+/// rate as its provenance.
+///
+/// An entry that fails mapping is skipped (logged individually with the reason,
+/// plus an aggregate count), never fabricated. A syntactically valid document
+/// from which ZERO entries map is a [`RateProviderError::Internal`] (returning
+/// `Ok([])` would read as success and suppress the composite fallback).
+///
+/// The feed is a system boundary, so the configured `base` and every `quote` key
+/// are gated on the ISO-4217 shape before they can reach a tenant's FX store: a
+/// malformed quote is skipped like any other unmappable entry, while a malformed
+/// configured `base` fails the whole document (it is operator config, not feed
+/// data, and would taint every rate).
+///
+/// # Errors
+/// [`RateProviderError::Internal`] if the `rates`/`as_of` paths are absent, the
+/// configured `base` is not ISO-4217-shaped, or no entry maps.
+pub fn map_json_document(
+    body: &Value,
+    mapping: &Mapping,
+    provider: &str,
+) -> Result<Vec<ProviderRate>, RateProviderError> {
+    let base = normalize_currency(&mapping.base).ok_or_else(|| {
+        RateProviderError::Internal(format!(
+            "configured mapping.base '{}' is not an ISO-4217-shaped currency code",
+            mapping.base
+        ))
+    })?;
+    let as_of_raw = json_lookup(body, &mapping.as_of)
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            RateProviderError::Internal(format!("as_of path '{}' missing", mapping.as_of))
+        })?;
+    let as_of: DateTime<Utc> = as_of_raw.parse().map_err(|e| {
+        RateProviderError::Internal(format!("as_of '{as_of_raw}' not RFC3339: {e}"))
+    })?;
+    let rates_obj = json_lookup(body, &mapping.rates)
+        .and_then(Value::as_object)
+        .ok_or_else(|| {
+            RateProviderError::Internal(format!(
+                "rates path '{}' missing or not an object",
+                mapping.rates
+            ))
+        })?;
+
+    let mut out = Vec::new();
+    let mut skipped: u64 = 0;
+    for (quote, entry) in rates_obj {
+        match map_entry(quote, entry, mapping, &base, as_of, provider) {
+            Some(rate) => out.push(rate),
+            None => skipped += 1,
+        }
+    }
+    if skipped > 0 {
+        tracing::warn!(
+            provider,
+            skipped,
+            "bss-rate-provider-http-json: skipped unmappable entries"
+        );
+    }
+    if out.is_empty() {
+        return Err(RateProviderError::Internal(
+            "http-json document produced zero mappable rates".to_owned(),
+        ));
+    }
+    Ok(out)
+}
+
+/// Map one `(quote, entry)` pair from the feed's rates object.
+///
+/// `None` means "skip this entry". Every skip path logs the offending quote and
+/// the reason: an aggregate "skipped N entries" alone would not tell an operator
+/// which currency of which feed started failing, or why.
+fn map_entry(
+    quote: &str,
+    entry: &Value,
+    mapping: &Mapping,
+    base: &str,
+    as_of: DateTime<Utc>,
+    provider: &str,
+) -> Option<ProviderRate> {
+    let normalized_quote = normalize_currency(quote).or_else(|| {
+        tracing::warn!(
+            provider,
+            quote = %quote,
+            "bss-rate-provider-http-json: skipping entry with a non-ISO-4217-shaped quote code"
+        );
+        None
+    })?;
+    let rate_val = entry.get(&mapping.rate).or_else(|| {
+        tracing::warn!(
+            provider,
+            quote = %normalized_quote,
+            rate_field = %mapping.rate,
+            "bss-rate-provider-http-json: skipping entry with no rate field"
+        );
+        None
+    })?;
+    let rate_str: Cow<'_, str> = match rate_val {
+        Value::String(s) => Cow::Borrowed(s.as_str()),
+        Value::Number(n) => Cow::Owned(n.to_string()),
+        _ => {
+            tracing::warn!(
+                provider,
+                quote = %normalized_quote,
+                "bss-rate-provider-http-json: skipping entry whose rate is neither string nor number"
+            );
+            return None;
+        }
+    };
+    match rate_to_micro(&rate_str) {
+        Ok(rate_micro) => Some(ProviderRate {
+            base: base.to_owned(),
+            quote: normalized_quote,
+            rate_micro,
+            as_of,
+            provider: provider.to_owned(),
+        }),
+        Err(e) => {
+            tracing::warn!(
+                provider,
+                quote = %normalized_quote,
+                error = %e,
+                "bss-rate-provider-http-json: skipping entry whose rate failed conversion"
+            );
+            None
+        }
+    }
+}
+
+/// The config-derived settings [`HttpJsonRateProvider`] needs, as one named
+/// struct rather than a positional argument list: `id` and `base_url` are
+/// adjacent `String`s that a positional constructor would let callers transpose
+/// without a compile error. The fields map 1:1 onto
+/// [`crate::config::HttpJsonPluginConfig`].
+#[derive(Debug, Clone)]
+pub struct HttpJsonSourceSettings {
+    /// Stable `provider_id`, stamped as provenance on every rate served.
+    pub id: String,
+    /// Feed endpoint (validated as https when the client is built).
+    pub base_url: String,
+    /// How the feed is authenticated, with its credential.
+    pub auth: Auth,
+    /// Field mapping — required for this source kind.
+    pub mapping: Mapping,
+}
+
+/// The generic http-json source.
+pub struct HttpJsonRateProvider {
+    settings: HttpJsonSourceSettings,
+    client: HttpClient,
+    metrics: SharedFetchMetrics,
+}
+
+impl HttpJsonRateProvider {
+    /// Build the source over its config-derived settings and a shared HTTP client.
+    #[must_use]
+    pub fn new(
+        settings: HttpJsonSourceSettings,
+        client: HttpClient,
+        metrics: SharedFetchMetrics,
+    ) -> Self {
+        Self {
+            settings,
+            client,
+            metrics,
+        }
+    }
+
+    /// Attach the configured credential to an outbound request.
+    ///
+    /// Shared by the fetch and the reachability probe so both hit the endpoint as
+    /// the same caller; a probe that skipped the credential would report on a
+    /// request the real fetch never makes. The credential travels inside the
+    /// `Auth` variant that needs it, so there is no "kind set but key missing"
+    /// arm, and every variant uses a header, so nothing here can leak into a
+    /// logged URL.
+    fn with_auth(&self, request: RequestBuilder) -> RequestBuilder {
+        match &self.settings.auth {
+            Auth::None {} => request,
+            Auth::Bearer { api_key } => request.header(
+                "Authorization",
+                &format!("Bearer {}", api_key.expose_secret()),
+            ),
+            Auth::HeaderKey { api_key } => request.header(API_KEY_HEADER, api_key.expose_secret()),
+        }
+    }
+}
+
+#[async_trait]
+impl RateProviderV1 for HttpJsonRateProvider {
+    fn provider_id(&self) -> &str {
+        &self.settings.id
+    }
+
+    async fn fetch_latest(
+        &self,
+        _ctx: &SecurityContext,
+        pairs: &[CurrencyPair],
+        _request_id: &str,
+    ) -> Result<Vec<ProviderRate>, RateProviderError> {
+        let request = self.with_auth(self.client.get(&self.settings.base_url));
+        fetch_and_parse(request, &self.settings.id, self.metrics.as_ref(), |bytes| {
+            let body: Value = serde_json::from_slice(bytes)
+                .map_err(|e| RateProviderError::Internal(format!("invalid JSON: {e}")))?;
+            let mut rates = map_json_document(&body, &self.settings.mapping, &self.settings.id)?;
+            // One `as_of` is parsed per document and copied onto every rate, so
+            // checking the first covers all of them. A document dated far enough
+            // ahead reads as permanently fresh to the ledger's age-based
+            // staleness rule; rejecting also lets the composite fall through to
+            // the next source instead of storing the bad value.
+            if let Some(first) = rates.first() {
+                reject_future_publication_time(first.as_of, Utc::now(), &self.settings.id)?;
+            }
+            let as_of_unix = rates.first().map_or(0, |r| r.as_of.timestamp());
+            if !pairs.is_empty() {
+                // Case-insensitive, matching the ECB source: both sit behind the
+                // same `CompositeRateProvider`, so a caller passing "usd" must
+                // not get rates from one source and nothing from the other.
+                rates.retain(|r| {
+                    pairs.iter().any(|p| {
+                        p.base.eq_ignore_ascii_case(&r.base)
+                            && p.quote.eq_ignore_ascii_case(&r.quote)
+                    })
+                });
+                // The contract's shared answer for "not served here", identical
+                // in the ECB source: a routine unsupported pair must not land on
+                // the fetch-error metric under the "internal" label, which is
+                // for real defects. Still an `Err`, so the composite moves on to
+                // a source that may publish the pair.
+                if rates.is_empty()
+                    && let Some(first) = pairs.first()
+                {
+                    return Err(RateProviderError::PairUnavailable {
+                        base: first.base.clone(),
+                        quote: first.quote.clone(),
+                    });
+                }
+            }
+            Ok((rates, as_of_unix))
+        })
+        .await
+    }
+
+    /// Cheap reachability probe: a HEAD against the configured `base_url`, never a
+    /// fetch+parse of the document.
+    ///
+    /// **Any HTTP response means reachable** — only a transport failure (DNS,
+    /// connect, TLS, timeout) is `Err`. That rule is what makes a HEAD usable for
+    /// an arbitrary configured feed: unlike ECB's static file, a JSON API commonly
+    /// answers `405 Method Not Allowed` to HEAD while serving GET perfectly, and
+    /// `401`/`403` if a credential is rotated. Each of those is the host
+    /// answering, so treating them as failures would report a working feed as
+    /// down. A non-success status is logged all the same.
+    ///
+    /// A deliberately weak signal, per the trait contract: it says nothing about
+    /// whether the document parses, whether `mapping` still matches the feed's
+    /// shape, or whether the rates are fresh. Freshness lives on
+    /// `fx_provider_last_success_timestamp`.
+    ///
+    /// The probe bypasses `fetch_and_parse` on purpose: touching those series
+    /// would advance the last-success gauge and the fetch-duration count,
+    /// silencing the freshness alerts meant to catch a feed whose real syncs fail.
+    async fn health(
+        &self,
+        _ctx: &SecurityContext,
+        _request_id: &str,
+    ) -> Result<(), RateProviderError> {
+        let resp = self
+            .with_auth(self.client.head(&self.settings.base_url))
+            .send()
+            .await
+            .map_err(|e| map_http_error(&e))?;
+        if !resp.status().is_success() {
+            tracing::warn!(
+                provider = %self.settings.id,
+                status = resp.status().as_u16(),
+                "bss-rate-provider-http-json: reachability probe answered with a non-success \
+                 status; the host answered, so the probe passes"
+            );
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[path = "source_tests.rs"]
+mod tests;

--- a/gears/bss/rate-provider/plugins/http-json-plugin/src/infra/source_tests.rs
+++ b/gears/bss/rate-provider/plugins/http-json-plugin/src/infra/source_tests.rs
@@ -1,0 +1,227 @@
+//! http-json mapping tests.
+
+use bss_ledger_sdk::RateProviderError;
+use serde_json::json;
+
+use super::{json_lookup, map_json_document};
+use crate::config::Mapping;
+
+/// The `provider_id` the mapper stamps onto every rate under test.
+const PROVIDER: &str = "http-json";
+
+fn mapping() -> Mapping {
+    Mapping {
+        base: "USD".to_owned(),
+        rates: "rates".to_owned(),
+        rate: "value".to_owned(),
+        as_of: "date".to_owned(),
+    }
+}
+
+#[test]
+fn dotted_lookup_walks_objects() {
+    let value = json!({"a": {"b": {"c": 1}}});
+    assert_eq!(json_lookup(&value, "a.b.c"), Some(&json!(1)));
+    assert_eq!(json_lookup(&value, "a.x"), None);
+}
+
+#[test]
+fn maps_entries_to_provider_rates() {
+    let body = json!({
+        "date": "2026-07-21T00:00:00Z",
+        "rates": { "EUR": {"value": "0.92"}, "GBP": {"value": "0.78"} }
+    });
+    let rates = map_json_document(&body, &mapping(), PROVIDER).unwrap();
+    assert_eq!(rates.len(), 2);
+    let eur = rates.iter().find(|r| r.quote == "EUR").unwrap();
+    assert_eq!(eur.base, "USD");
+    assert_eq!(eur.rate_micro, 920_000);
+}
+
+#[test]
+fn every_rate_is_stamped_with_the_serving_provider_id() {
+    // Provenance is per-rate, so the ledger records the true upstream on every
+    // stored row instead of reading back a racy `provider_id()`.
+    let body = json!({
+        "date": "2026-07-21T00:00:00Z",
+        "rates": { "EUR": {"value": "0.92"} }
+    });
+    let rates = map_json_document(&body, &mapping(), "bank-x").unwrap();
+    assert!(rates.iter().all(|r| r.provider == "bank-x"));
+}
+
+#[test]
+fn zero_mappable_entries_is_internal_error() {
+    let body = json!({ "date": "2026-07-21T00:00:00Z", "rates": {} });
+    assert!(matches!(
+        map_json_document(&body, &mapping(), PROVIDER),
+        Err(RateProviderError::Internal(_))
+    ));
+}
+
+#[test]
+fn unmappable_entry_is_skipped_not_fatal() {
+    let body = json!({
+        "date": "2026-07-21T00:00:00Z",
+        "rates": { "EUR": {"value": "0.92"}, "BAD": {"nope": 1} }
+    });
+    let rates = map_json_document(&body, &mapping(), PROVIDER).unwrap();
+    assert_eq!(rates.len(), 1);
+}
+
+#[test]
+fn all_entries_present_but_all_unmappable_is_internal_error() {
+    // `rates` is non-empty but every entry fails to map, so the check must key off
+    // "how many mapped", not "was the object non-empty".
+    let body = json!({
+        "date": "2026-07-21T00:00:00Z",
+        "rates": { "EUR": {"nope": 1}, "GBP": {"value": "not-a-number"} }
+    });
+    assert!(matches!(
+        map_json_document(&body, &mapping(), PROVIDER),
+        Err(RateProviderError::Internal(_))
+    ));
+}
+
+#[test]
+fn numeric_rate_is_accepted_as_well_as_string() {
+    let body = json!({
+        "date": "2026-07-21T00:00:00Z",
+        "rates": { "EUR": {"value": 0.92} }
+    });
+    let rates = map_json_document(&body, &mapping(), PROVIDER).unwrap();
+    assert_eq!(rates[0].rate_micro, 920_000);
+}
+
+#[test]
+fn a_rate_that_is_neither_string_nor_number_is_skipped() {
+    // A distinct case from "no rate field": the field is present, so the mapping
+    // still matches the feed's shape, but the value has a JSON type no rate can be
+    // read out of. Skipping (not erroring) keeps one malformed currency from
+    // costing the whole document.
+    let body = json!({
+        "date": "2026-07-21T00:00:00Z",
+        "rates": {
+            "EUR": {"value": "0.92"},
+            "GBP": {"value": true},
+            "CHF": {"value": {"nested": 1}},
+            "JPY": {"value": ["160.85"]}
+        }
+    });
+    let rates = map_json_document(&body, &mapping(), PROVIDER).unwrap();
+    assert_eq!(rates.len(), 1, "only the readable rate survives");
+    assert_eq!(rates[0].quote, "EUR");
+}
+
+#[test]
+fn missing_as_of_path_is_internal_error() {
+    // A regression that defaulted a missing `as_of` to `now()` would silently
+    // mis-timestamp every rate and pass every other test in this file.
+    let body = json!({ "rates": { "EUR": {"value": "0.92"} } });
+    assert!(matches!(
+        map_json_document(&body, &mapping(), PROVIDER),
+        Err(RateProviderError::Internal(_))
+    ));
+}
+
+#[test]
+fn non_rfc3339_as_of_is_internal_error() {
+    let body = json!({
+        "date": "21 July 2026",
+        "rates": { "EUR": {"value": "0.92"} }
+    });
+    assert!(matches!(
+        map_json_document(&body, &mapping(), PROVIDER),
+        Err(RateProviderError::Internal(_))
+    ));
+}
+
+#[test]
+fn non_string_as_of_is_internal_error() {
+    let body = json!({
+        "date": 1_753_056_000,
+        "rates": { "EUR": {"value": "0.92"} }
+    });
+    assert!(matches!(
+        map_json_document(&body, &mapping(), PROVIDER),
+        Err(RateProviderError::Internal(_))
+    ));
+}
+
+#[test]
+fn missing_rates_path_is_internal_error() {
+    let body = json!({ "date": "2026-07-21T00:00:00Z" });
+    assert!(matches!(
+        map_json_document(&body, &mapping(), PROVIDER),
+        Err(RateProviderError::Internal(_))
+    ));
+}
+
+#[test]
+fn rates_path_that_is_not_an_object_is_internal_error() {
+    let body = json!({ "date": "2026-07-21T00:00:00Z", "rates": ["EUR", "GBP"] });
+    assert!(matches!(
+        map_json_document(&body, &mapping(), PROVIDER),
+        Err(RateProviderError::Internal(_))
+    ));
+}
+
+#[test]
+fn non_iso4217_shaped_quote_is_skipped_not_stored() {
+    // The feed is a system boundary: an arbitrary string must never reach a
+    // tenant's FX store as a currency identifier.
+    let body = json!({
+        "date": "2026-07-21T00:00:00Z",
+        "rates": {
+            "EUR": {"value": "0.92"},
+            "NOT-A-CURRENCY": {"value": "1.0"},
+            "E$R": {"value": "1.0"},
+            "": {"value": "1.0"}
+        }
+    });
+    let rates = map_json_document(&body, &mapping(), PROVIDER).unwrap();
+    assert_eq!(rates.len(), 1, "only the well-formed quote survives");
+    assert_eq!(rates[0].quote, "EUR");
+}
+
+#[test]
+fn lowercase_quote_is_normalized_to_uppercase() {
+    let body = json!({
+        "date": "2026-07-21T00:00:00Z",
+        "rates": { "eur": {"value": "0.92"} }
+    });
+    let rates = map_json_document(&body, &mapping(), PROVIDER).unwrap();
+    assert_eq!(rates[0].quote, "EUR");
+}
+
+#[test]
+fn misconfigured_base_currency_fails_the_whole_document() {
+    // The base is operator config, not feed data — a malformed one would taint
+    // every rate in the document, so it is fatal rather than per-entry skipped.
+    let body = json!({
+        "date": "2026-07-21T00:00:00Z",
+        "rates": { "EUR": {"value": "0.92"} }
+    });
+    let bad_base = Mapping {
+        base: "US DOLLAR".to_owned(),
+        ..mapping()
+    };
+    assert!(matches!(
+        map_json_document(&body, &bad_base, PROVIDER),
+        Err(RateProviderError::Internal(_))
+    ));
+}
+
+#[test]
+fn lowercase_configured_base_is_normalized_to_uppercase() {
+    let body = json!({
+        "date": "2026-07-21T00:00:00Z",
+        "rates": { "EUR": {"value": "0.92"} }
+    });
+    let lower_base = Mapping {
+        base: "usd".to_owned(),
+        ..mapping()
+    };
+    let rates = map_json_document(&body, &lower_base, PROVIDER).unwrap();
+    assert_eq!(rates[0].base, "USD");
+}

--- a/gears/bss/rate-provider/plugins/http-json-plugin/src/lib.rs
+++ b/gears/bss/rate-provider/plugins/http-json-plugin/src/lib.rs
@@ -1,0 +1,16 @@
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+//! `bss-rate-provider-http-json-plugin` — a generic GET-JSON source plugin.
+//!
+//! Fetches a plain REST rate feed, applies a configured field `mapping`, and
+//! registers itself as a [`bss_ledger_sdk::RateProviderV1`] source plugin
+//! (`PluginV1<RateProviderSourcePluginSpecV1>` instance + scoped `ClientHub`
+//! entry). v1 scope (design O-11): single literal base currency, simple dotted
+//! field paths, `none`/`bearer`/`header-key` auth.
+
+pub mod config;
+pub mod gear;
+// `pub`, not `pub(crate)`: `tests/http_json_integration.rs` constructs
+// `HttpJsonRateProvider` directly.
+pub mod infra;
+
+pub use gear::HttpJsonRateProviderPlugin;

--- a/gears/bss/rate-provider/plugins/http-json-plugin/tests/http_json_integration.rs
+++ b/gears/bss/rate-provider/plugins/http-json-plugin/tests/http_json_integration.rs
@@ -1,0 +1,348 @@
+//! Integration: `HttpJsonRateProvider` end-to-end over a local axum server —
+//! covers the network path (auth headers, upstream status, transport
+//! failure) the pure-function unit tests in `source_tests.rs` skip.
+#![allow(
+    clippy::unwrap_used,
+    reason = "integration-test setup helpers: an unwrap here just fails the test"
+)]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::Router;
+use axum::http::{HeaderMap, StatusCode};
+use axum::routing::{MethodFilter, get, on};
+use bss_ledger_sdk::{CurrencyPair, RateProviderError, RateProviderV1};
+use bss_rate_provider_http_json_plugin::config::{Auth, Mapping};
+use bss_rate_provider_http_json_plugin::infra::source::{
+    HttpJsonRateProvider, HttpJsonSourceSettings,
+};
+use bss_rate_provider_sdk::metrics::NoopFetchMetrics;
+use secrecy::SecretString;
+use toolkit_http::HttpClient;
+use toolkit_security::SecurityContext;
+
+/// USD-based feed, two quotes.
+const BODY: &str =
+    r#"{"date":"2026-07-21T00:00:00Z","rates":{"EUR":{"value":"0.92"},"GBP":{"value":"0.78"}}}"#;
+
+/// The same feed dated far enough ahead that no plausible clock skew could
+/// explain it. A fixed year rather than `now() + n` keeps this a `&'static str`,
+/// and it stays "the future" for as long as this code exists.
+const FUTURE_DATED_BODY: &str =
+    r#"{"date":"9999-12-31T00:00:00Z","rates":{"EUR":{"value":"0.92"}}}"#;
+
+/// The configured `provider_id`, also the provenance stamped on every rate.
+const PROVIDER: &str = "http-json";
+
+fn mapping() -> Mapping {
+    Mapping {
+        base: "USD".to_owned(),
+        rates: "rates".to_owned(),
+        rate: "value".to_owned(),
+        as_of: "date".to_owned(),
+    }
+}
+
+/// Spawns a fake JSON rate feed. `expected_header`, if set, is required on the
+/// request (name, value) — the response is 401 when it's missing/wrong, so an
+/// auth-header test fails loudly instead of silently passing on an
+/// unauthenticated request.
+async fn spawn_server(
+    status: u16,
+    expected_header: Option<(&'static str, &'static str)>,
+) -> (String, tokio::task::JoinHandle<()>) {
+    let app = Router::new().route(
+        "/rates",
+        get(move |headers: HeaderMap| async move {
+            if let Some((name, value)) = expected_header {
+                let actual = headers.get(name).and_then(|v| v.to_str().ok());
+                if actual != Some(value) {
+                    return (StatusCode::UNAUTHORIZED, String::new());
+                }
+            }
+            (StatusCode::from_u16(status).unwrap(), BODY.to_owned())
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    (format!("http://{addr}/rates"), handle)
+}
+
+/// Like [`spawn_server`], but serves an arbitrary body with no auth check —
+/// for tests about the document's own content rather than the request.
+async fn spawn_body_server(body: &'static str) -> (String, tokio::task::JoinHandle<()>) {
+    let app = Router::new().route("/rates", get(move || async move { (StatusCode::OK, body) }));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    (format!("http://{addr}/rates"), handle)
+}
+
+fn provider(url: String, auth: Auth) -> HttpJsonRateProvider {
+    // Loopback is plain HTTP; a non-FIPS test client allows insecure http.
+    let client = HttpClient::builder()
+        .timeout(Duration::from_secs(2))
+        .build()
+        .unwrap();
+    HttpJsonRateProvider::new(
+        HttpJsonSourceSettings {
+            id: PROVIDER.to_owned(),
+            base_url: url,
+            auth,
+            mapping: mapping(),
+        },
+        client,
+        Arc::new(NoopFetchMetrics),
+    )
+}
+
+/// A `Bearer` auth carrying `secret-key`.
+fn bearer(key: &str) -> Auth {
+    Auth::Bearer {
+        api_key: SecretString::from(key.to_owned()),
+    }
+}
+
+/// A feed that accepts GET but **not** HEAD, so a HEAD probe gets axum's `405`.
+///
+/// `get()` would answer HEAD too (axum routes it to the GET handler), which is the
+/// behaviour this server must not have: many real JSON APIs reject HEAD, and the
+/// probe has to stay green against them.
+async fn spawn_get_only_server() -> (String, tokio::task::JoinHandle<()>) {
+    let app = Router::new().route(
+        "/rates",
+        on(
+            MethodFilter::GET,
+            move || async move { (StatusCode::OK, BODY) },
+        ),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    (format!("http://{addr}/rates"), handle)
+}
+
+#[tokio::test]
+async fn health_probe_succeeds_when_the_feed_answers() {
+    let (url, _server) = spawn_server(200, None).await;
+    let p = provider(url, Auth::None {});
+    let ctx = SecurityContext::anonymous();
+    p.health(&ctx, "req").await.unwrap();
+}
+
+#[tokio::test]
+async fn health_probe_passes_when_the_feed_rejects_head() {
+    // A 405 is the host answering "not that method", which proves reachability;
+    // treating it as unhealthy would report a working GET-serving feed as down.
+    let (url, _server) = spawn_get_only_server().await;
+    let p = provider(url, Auth::None {});
+    let ctx = SecurityContext::anonymous();
+    assert!(
+        p.health(&ctx, "req").await.is_ok(),
+        "a feed that rejects HEAD is still reachable"
+    );
+}
+
+#[tokio::test]
+async fn health_probe_passes_on_a_non_success_status() {
+    // Same rule for a server-side failure: a 503 means the request arrived.
+    let (url, _server) = spawn_server(503, None).await;
+    let p = provider(url, Auth::None {});
+    let ctx = SecurityContext::anonymous();
+    assert!(p.health(&ctx, "req").await.is_ok());
+}
+
+#[tokio::test]
+async fn health_probe_fails_only_when_nothing_gets_through() {
+    // The other side of the bound: bind then drop, so the port is free and the
+    // request dies at the transport level — the one genuinely unreachable case.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    drop(listener);
+
+    let p = provider(format!("http://{addr}/rates"), Auth::None {});
+    let ctx = SecurityContext::anonymous();
+    let err = p.health(&ctx, "req").await.unwrap_err();
+    assert!(
+        matches!(err, RateProviderError::Unreachable(_)),
+        "a transport failure must be Unreachable, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn a_future_dated_document_is_rejected_rather_than_served() {
+    // A future `as_of` has a negative age, so the ledger's age-based staleness
+    // rule would read it as fresh forever. It must fail the fetch instead, which
+    // also lets the composite fall through to the next source.
+    let (url, _server) = spawn_body_server(FUTURE_DATED_BODY).await;
+    let p = provider(url, Auth::None {});
+    let ctx = SecurityContext::anonymous();
+    let err = p.fetch_latest(&ctx, &[], "req").await.unwrap_err();
+    assert!(
+        matches!(err, RateProviderError::Internal(ref m) if m.contains("9999-12-31")),
+        "expected the rejection to name the offending publication time, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn full_fetch_returns_whole_document() {
+    let (url, _server) = spawn_server(200, None).await;
+    let p = provider(url, Auth::None {});
+    let ctx = SecurityContext::anonymous();
+    let rates = p.fetch_latest(&ctx, &[], "req").await.unwrap();
+    assert_eq!(rates.len(), 2);
+}
+
+#[tokio::test]
+async fn every_served_rate_carries_this_sources_provenance() {
+    let (url, _server) = spawn_server(200, None).await;
+    let p = provider(url, Auth::None {});
+    let ctx = SecurityContext::anonymous();
+    let rates = p.fetch_latest(&ctx, &[], "req").await.unwrap();
+    assert!(rates.iter().all(|r| r.provider == PROVIDER));
+}
+
+#[tokio::test]
+async fn out_of_base_pair_is_omitted_not_synthesized() {
+    let (url, _server) = spawn_server(200, None).await;
+    let p = provider(url, Auth::None {});
+    let ctx = SecurityContext::anonymous();
+    // The feed's base is USD; a EUR-base request must be omitted, not derived. It
+    // is the ONLY requested pair, so filtering leaves nothing, which must surface
+    // as an error (never a bare `Ok([])`) so the composite falls back instead of
+    // treating this as a served-but-empty tick. `PairUnavailable` — the same
+    // answer the ECB source gives — keeps a routine "not served here" off the
+    // fetch-error metric's "internal" label.
+    let want = vec![CurrencyPair {
+        base: "EUR".to_owned(),
+        quote: "GBP".to_owned(),
+    }];
+    let err = p.fetch_latest(&ctx, &want, "req").await.unwrap_err();
+    assert!(
+        matches!(&err, RateProviderError::PairUnavailable { base, quote } if base == "EUR" && quote == "GBP"),
+        "expected PairUnavailable naming the requested pair, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn matching_pair_filter_returns_only_that_pair() {
+    let (url, _server) = spawn_server(200, None).await;
+    let p = provider(url, Auth::None {});
+    let ctx = SecurityContext::anonymous();
+    let want = vec![CurrencyPair {
+        base: "USD".to_owned(),
+        quote: "GBP".to_owned(),
+    }];
+    let rates = p.fetch_latest(&ctx, &want, "req").await.unwrap();
+    assert_eq!(rates.len(), 1);
+    assert_eq!(rates[0].quote, "GBP");
+}
+
+#[tokio::test]
+async fn pair_filter_is_case_insensitive_like_the_ecb_source() {
+    // Both sources sit behind one `CompositeRateProvider`, so a caller passing
+    // lowercase codes must not get rates from one and nothing from the other.
+    let (url, _server) = spawn_server(200, None).await;
+    let p = provider(url, Auth::None {});
+    let ctx = SecurityContext::anonymous();
+    let want = vec![CurrencyPair {
+        base: "usd".to_owned(),
+        quote: "gbp".to_owned(),
+    }];
+    let rates = p.fetch_latest(&ctx, &want, "req").await.unwrap();
+    assert_eq!(rates.len(), 1);
+    assert_eq!(rates[0].quote, "GBP");
+}
+
+#[tokio::test]
+async fn bearer_auth_sends_the_authorization_header() {
+    let (url, _server) = spawn_server(200, Some(("authorization", "Bearer secret-key"))).await;
+    let p = provider(url, bearer("secret-key"));
+    let ctx = SecurityContext::anonymous();
+    let rates = p.fetch_latest(&ctx, &[], "req").await.unwrap();
+    assert_eq!(rates.len(), 2);
+}
+
+#[tokio::test]
+async fn header_key_auth_sends_the_custom_header() {
+    let (url, _server) = spawn_server(200, Some(("x-api-key", "secret-key"))).await;
+    let p = provider(
+        url,
+        Auth::HeaderKey {
+            api_key: SecretString::from("secret-key".to_owned()),
+        },
+    );
+    let ctx = SecurityContext::anonymous();
+    let rates = p.fetch_latest(&ctx, &[], "req").await.unwrap();
+    assert_eq!(rates.len(), 2);
+}
+
+#[tokio::test]
+async fn no_auth_sends_no_credential_and_an_authenticated_feed_rejects_it() {
+    // `Auth::None {}` against a feed that requires a key: the request goes out
+    // unauthenticated and surfaces the upstream's 401 rather than being retried
+    // or masked.
+    let (url, _server) = spawn_server(200, Some(("authorization", "Bearer secret-key"))).await;
+    let p = provider(url, Auth::None {});
+    let ctx = SecurityContext::anonymous();
+    let err = p.fetch_latest(&ctx, &[], "req").await.unwrap_err();
+    assert!(matches!(err, RateProviderError::UpstreamStatus(401)));
+}
+
+#[tokio::test]
+async fn wrong_credential_surfaces_the_upstream_status() {
+    let (url, _server) = spawn_server(200, Some(("authorization", "Bearer secret-key"))).await;
+    let p = provider(url, bearer("wrong-key"));
+    let ctx = SecurityContext::anonymous();
+    let err = p.fetch_latest(&ctx, &[], "req").await.unwrap_err();
+    assert!(matches!(err, RateProviderError::UpstreamStatus(401)));
+}
+
+#[tokio::test]
+async fn upstream_503_maps_to_upstream_status() {
+    let (url, _server) = spawn_server(503, None).await;
+    let p = provider(url, Auth::None {});
+    let ctx = SecurityContext::anonymous();
+    let err = p.fetch_latest(&ctx, &[], "req").await.unwrap_err();
+    assert!(matches!(err, RateProviderError::UpstreamStatus(503)));
+}
+
+#[tokio::test]
+async fn connection_refused_maps_to_unreachable() {
+    // Bind then immediately drop the listener: the port is free, but nothing
+    // is listening, so any request to it fails at the transport level.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    drop(listener);
+
+    let p = provider(format!("http://{addr}/rates"), Auth::None {});
+    let ctx = SecurityContext::anonymous();
+    let err = p.fetch_latest(&ctx, &[], "req").await.unwrap_err();
+    assert!(matches!(err, RateProviderError::Unreachable(_)));
+}
+
+#[tokio::test]
+async fn provider_id_reports_the_configured_id_not_a_hardcoded_one() {
+    // This id is what the operator sets per feed, and it is also the provenance
+    // stamped on every rate. A hardcoded value would make two feeds onboarded
+    // through this same plugin indistinguishable in the ledger's stored rows —
+    // exactly the case config-only onboarding is meant to support.
+    let (url, _server) = spawn_server(200, None).await;
+    let p = provider(url, Auth::None {});
+    assert_eq!(p.provider_id(), PROVIDER);
+
+    let ctx = SecurityContext::anonymous();
+    let rates = p.fetch_latest(&ctx, &[], "req").await.unwrap();
+    assert!(
+        rates.iter().all(|r| r.provider == p.provider_id()),
+        "every served rate must carry the same id the source reports"
+    );
+}

--- a/gears/bss/rate-provider/rate-provider-sdk/Cargo.toml
+++ b/gears/bss/rate-provider/rate-provider-sdk/Cargo.toml
@@ -1,0 +1,50 @@
+[package]
+name = "bss-rate-provider-sdk"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+description = "BSS FX rate-provider SDK: the source-plugin GTS spec + shared source utilities (conversion, error mapping, fetch metrics)"
+
+[lints]
+workspace = true
+
+[dependencies]
+# The fixed cross-gear contract the sources implement (RateProviderError / ProviderRate).
+bss-ledger-sdk = { workspace = true }
+# GTS PluginV1 base + the `#[gts_type_schema]` / `gts_id!` macros for the source-plugin spec.
+toolkit-gts = { workspace = true }
+# The macro expansion references the `gts` crate directly (same as other -sdk crates).
+gts = { workspace = true }
+# `#[gts_type_schema]` expands to `schemars`-derived JSON-schema code.
+schemars = { workspace = true }
+# GearCtx, ClientHub/ClientScope, gts::PluginV1 re-export — shared plugin-registration
+# + HTTP-client-builder helpers wire straight into a gear's init().
+toolkit = { workspace = true }
+# Plugin registration (RegisterResult, TypesRegistryClient) for the shared registration helper.
+types-registry-sdk = { workspace = true }
+# Outbound HTTP error type mapped by `error::map_http_error`; shared client builder + fetch helper.
+toolkit-http = { workspace = true, features = ["otel"] }
+# `Uri` for validating a source's `base_url` at gear init. Deliberately the same
+# parser `toolkit-http` uses on the request path, so this gate applies identical
+# scheme normalization instead of second-guessing it with string matching.
+http = { workspace = true }
+# OTel metrics seam for the shared fetch metrics.
+opentelemetry = { workspace = true }
+# Exact-decimal parse + banker's rounding for rate_micro (never f64).
+rust_decimal = { workspace = true }
+tracing = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+# Error propagation for the shared gear-wiring helpers (registration, HTTP client build).
+anyhow = { workspace = true }
+# `DateTime<Utc>` arithmetic for the shared publication-time (clock-skew) guard.
+chrono = { workspace = true }
+
+[dev-dependencies]
+# fetch_tests.rs drives `fetch_and_parse` over a real in-process HTTP server
+# (the only way to exercise its metrics contract on every response branch).
+tokio = { workspace = true }
+axum = { workspace = true }
+# metrics_tests.rs exports recorded instruments in-memory to assert real
+# instrument names, labels, and values; `testing` gates InMemoryMetricExporter.
+opentelemetry_sdk = { workspace = true, features = ["testing"] }

--- a/gears/bss/rate-provider/rate-provider-sdk/src/conversion.rs
+++ b/gears/bss/rate-provider/rate-provider-sdk/src/conversion.rs
@@ -1,0 +1,54 @@
+//! Deterministic conversion of a published decimal rate string into the
+//! contract's fixed-precision integer `rate_micro = round(rate * 1e6)`. Shared by
+//! every rate-provider source plugin.
+//!
+//! Parses into an EXACT decimal (`rust_decimal::Decimal`, never binary `f64`,
+//! whose nearest-representable value can mis-round exact half-way decimals) and
+//! rounds half-to-even (banker's rounding) to match the platform ledger rounding
+//! default, so a re-fetch of the same published rate yields the same integer.
+//! Overflow / non-finite / non-numeric input maps to
+//! [`RateProviderError::Internal`] — never a silent truncation.
+//!
+//! **A rate must be strictly positive.** Zero and negative values are rejected,
+//! not converted: the domain has no use for them (confirmed with the BSS billing
+//! owner), and letting one through would zero out or flip the sign of every
+//! downstream translation. The ledger's own store gates on `rate_micro > 0` as a
+//! second line of defence; rejecting here means the provider feed never gets
+//! that far.
+
+use bss_ledger_sdk::RateProviderError;
+use rust_decimal::prelude::ToPrimitive;
+use rust_decimal::{Decimal, RoundingStrategy};
+
+/// Fixed-precision scale: the functional-per-unit-base multiplier is stored `* 1e6`.
+const MICRO: i64 = 1_000_000;
+
+/// Convert a published decimal rate string to a strictly-positive `rate_micro`
+/// (`i64`).
+///
+/// # Errors
+/// [`RateProviderError::Internal`] if the string is not an exact decimal, the
+/// scaled/rounded value does not fit in `i64`, or the result is not `> 0` (see
+/// the module docs on why zero and negative rates are rejected outright).
+pub fn rate_to_micro(rate: &str) -> Result<i64, RateProviderError> {
+    let parsed = Decimal::from_str_exact(rate.trim()).map_err(|e| {
+        RateProviderError::Internal(format!("rate '{rate}' is not an exact decimal: {e}"))
+    })?;
+    let scaled = parsed.checked_mul(Decimal::from(MICRO)).ok_or_else(|| {
+        RateProviderError::Internal(format!("rate '{rate}' overflows when scaled to micro"))
+    })?;
+    let rounded = scaled.round_dp_with_strategy(0, RoundingStrategy::MidpointNearestEven);
+    let rate_micro = rounded
+        .to_i64()
+        .ok_or_else(|| RateProviderError::Internal(format!("rate '{rate}' out of i64 range")))?;
+    if rate_micro <= 0 {
+        return Err(RateProviderError::Internal(format!(
+            "rate '{rate}' must round to a positive micro value"
+        )));
+    }
+    Ok(rate_micro)
+}
+
+#[cfg(test)]
+#[path = "conversion_tests.rs"]
+mod tests;

--- a/gears/bss/rate-provider/rate-provider-sdk/src/conversion_tests.rs
+++ b/gears/bss/rate-provider/rate-provider-sdk/src/conversion_tests.rs
@@ -1,0 +1,124 @@
+//! Golden-vector + edge tests for the exact-decimal `rate_micro` conversion.
+
+use bss_ledger_sdk::RateProviderError;
+
+use super::rate_to_micro;
+
+#[test]
+fn typical_ecb_rate() {
+    // 1.0856 * 1e6 = 1_085_600 exactly.
+    assert_eq!(rate_to_micro("1.0856").unwrap(), 1_085_600);
+}
+
+#[test]
+fn banker_rounding_half_to_even() {
+    // 0.0000015 * 1e6 = 1.5 -> nearest even = 2.
+    assert_eq!(rate_to_micro("0.0000015").unwrap(), 2);
+    // 0.0000025 * 1e6 = 2.5 -> nearest even = 2.
+    assert_eq!(rate_to_micro("0.0000025").unwrap(), 2);
+    // 0.0000035 * 1e6 = 3.5 -> nearest even = 4.
+    assert_eq!(rate_to_micro("0.0000035").unwrap(), 4);
+}
+
+#[test]
+fn deterministic_repeat() {
+    assert_eq!(
+        rate_to_micro("160.85").unwrap(),
+        rate_to_micro("160.85").unwrap()
+    );
+    assert_eq!(rate_to_micro("160.85").unwrap(), 160_850_000);
+}
+
+#[test]
+fn non_numeric_is_internal_error() {
+    assert!(matches!(
+        rate_to_micro("abc"),
+        Err(RateProviderError::Internal(_))
+    ));
+}
+
+#[test]
+fn overflow_is_internal_error() {
+    assert!(matches!(
+        rate_to_micro("100000000000000"),
+        Err(RateProviderError::Internal(_))
+    ));
+}
+
+#[test]
+fn zero_rate_is_internal_error() {
+    // A corrupted or empty feed value must not convert "successfully" to zero.
+    assert!(matches!(
+        rate_to_micro("0"),
+        Err(RateProviderError::Internal(_))
+    ));
+    assert!(matches!(
+        rate_to_micro("0.000000"),
+        Err(RateProviderError::Internal(_))
+    ));
+}
+
+#[test]
+fn negative_rate_is_internal_error() {
+    assert!(matches!(
+        rate_to_micro("-1.5"),
+        Err(RateProviderError::Internal(_))
+    ));
+}
+
+#[test]
+fn negative_banker_rounding_result_is_internal_error() {
+    // -0.0000025 * 1e6 = -2.5 -> nearest even = -2: rounded correctly, still
+    // rejected as non-positive.
+    assert!(matches!(
+        rate_to_micro("-0.0000025"),
+        Err(RateProviderError::Internal(_))
+    ));
+}
+
+#[test]
+fn exact_i64_max_boundary_converts_exactly() {
+    // i64::MAX = 9_223_372_036_854_775_807; this rate scales to exactly that.
+    assert_eq!(rate_to_micro("9223372036854.775807").unwrap(), i64::MAX);
+}
+
+#[test]
+fn one_micro_past_i64_max_is_internal_error() {
+    assert!(matches!(
+        rate_to_micro("9223372036854.775808"),
+        Err(RateProviderError::Internal(_))
+    ));
+}
+
+#[test]
+fn exact_i64_min_magnitude_negative_rate_is_internal_error() {
+    // The magnitude fits i64 exactly, so this is rejected as non-positive rather
+    // than as an overflow.
+    assert!(matches!(
+        rate_to_micro("-9223372036854.775808"),
+        Err(RateProviderError::Internal(_))
+    ));
+}
+
+#[test]
+fn one_micro_past_i64_min_is_internal_error() {
+    // This one overflows i64 outright, on top of being negative.
+    assert!(matches!(
+        rate_to_micro("-9223372036854.775809"),
+        Err(RateProviderError::Internal(_))
+    ));
+}
+
+#[test]
+fn a_rate_too_large_to_scale_fails_at_the_scaling_step() {
+    // A distinct failure from the i64 cases above: 1e23 parses as an exact
+    // `Decimal`, but 1e23 * 1e6 exceeds `Decimal::MAX` (~7.9e28), so the
+    // multiplication itself has nowhere to put the result and never reaches the
+    // i64 conversion. Asserting the message is what separates the two paths —
+    // both are `Internal`, so `matches!` alone cannot tell them apart.
+    let err = rate_to_micro("100000000000000000000000").unwrap_err();
+    assert!(
+        err.to_string().contains("overflows when scaled to micro"),
+        "expected the scaling-overflow error, got: {err}"
+    );
+}

--- a/gears/bss/rate-provider/rate-provider-sdk/src/currency.rs
+++ b/gears/bss/rate-provider/rate-provider-sdk/src/currency.rs
@@ -1,0 +1,36 @@
+//! ISO-4217 currency-code shape validation at the feed boundary. Shared by every
+//! rate-provider source plugin.
+//!
+//! A remote feed's currency identifiers end up as `ledger_fx_rate.base_currency` /
+//! `.quote_currency` in every tenant's store, so a compromised or misconfigured
+//! upstream must not be able to inject arbitrary strings there. The feed response
+//! is a system boundary: rates and timestamps are already validated, and these
+//! helpers close the same gap for the codes themselves.
+//!
+//! Shape-only, deliberately: this checks the ISO-4217 *form* (three ASCII
+//! letters), not membership of the current ISO-4217 register. Validating against
+//! a hardcoded code list would reject legitimately-published new or exotic codes
+//! the moment the register moves ahead of our copy of it, which for a fetch-only
+//! adapter is a worse failure than passing an unknown-but-well-formed code
+//! through to the ledger.
+
+/// True when `code` has the ISO-4217 shape: exactly three ASCII letters.
+#[must_use]
+pub fn is_iso4217_shaped(code: &str) -> bool {
+    code.len() == 3 && code.bytes().all(|b| b.is_ascii_alphabetic())
+}
+
+/// Normalize a feed-supplied currency code to canonical uppercase ISO-4217,
+/// or `None` when it is not ISO-4217-shaped.
+///
+/// Uppercasing keeps the stored code canonical regardless of how the upstream
+/// cased it, so the ledger never ends up with both `"usd"` and `"USD"` rows for
+/// the same currency.
+#[must_use]
+pub fn normalize_currency(code: &str) -> Option<String> {
+    is_iso4217_shaped(code).then(|| code.to_ascii_uppercase())
+}
+
+#[cfg(test)]
+#[path = "currency_tests.rs"]
+mod tests;

--- a/gears/bss/rate-provider/rate-provider-sdk/src/currency_tests.rs
+++ b/gears/bss/rate-provider/rate-provider-sdk/src/currency_tests.rs
@@ -1,0 +1,50 @@
+//! Tests for the ISO-4217 shape gate applied to feed-supplied currency codes.
+
+use super::{is_iso4217_shaped, normalize_currency};
+
+#[test]
+fn accepts_canonical_three_letter_codes() {
+    assert!(is_iso4217_shaped("USD"));
+    assert!(is_iso4217_shaped("eur"));
+    assert_eq!(normalize_currency("USD").as_deref(), Some("USD"));
+}
+
+#[test]
+fn normalizes_case_so_the_store_never_holds_two_rows_per_currency() {
+    assert_eq!(normalize_currency("usd").as_deref(), Some("USD"));
+    assert_eq!(normalize_currency("uSd").as_deref(), Some("USD"));
+}
+
+#[test]
+fn rejects_wrong_length() {
+    for code in ["", "U", "US", "USDX"] {
+        assert!(!is_iso4217_shaped(code), "{code} must be rejected");
+        assert!(
+            normalize_currency(code).is_none(),
+            "{code} must be rejected"
+        );
+    }
+}
+
+#[test]
+fn rejects_non_alphabetic_and_injection_shaped_input() {
+    // The point of the gate: a compromised feed must not get arbitrary strings
+    // into a tenant's persistent FX store as a currency identifier.
+    for code in ["US1", "U$D", "US ", " US", "US\n", "US;", "'--"] {
+        assert!(!is_iso4217_shaped(code), "{code:?} must be rejected");
+        assert!(
+            normalize_currency(code).is_none(),
+            "{code:?} must be rejected"
+        );
+    }
+}
+
+#[test]
+fn rejects_multibyte_input_that_is_three_bytes_but_not_three_letters() {
+    // U+00E9 ("e" with acute) is 2 bytes in UTF-8, so this is 3 BYTES but only 2
+    // chars — the byte-length check must not let it pass as a 3-letter code.
+    // Escapes rather than literals: the workspace denies non-ASCII literals.
+    assert!(!is_iso4217_shaped("\u{e9}a"));
+    // U+20AC (euro sign) is 3 bytes, 1 char.
+    assert!(!is_iso4217_shaped("\u{20ac}"));
+}

--- a/gears/bss/rate-provider/rate-provider-sdk/src/error.rs
+++ b/gears/bss/rate-provider/rate-provider-sdk/src/error.rs
@@ -1,0 +1,71 @@
+//! Maps `toolkit_http::HttpError` onto the ledger contract's `RateProviderError`.
+//! Shared by every rate-provider source plugin.
+//!
+//! Transport-level failures (timeout, DNS, TLS, connection) become
+//! [`RateProviderError::Unreachable`]; a decoded non-success HTTP status becomes
+//! [`RateProviderError::UpstreamStatus`]; everything else (bad URL, oversized
+//! body, JSON decode fault) is a local [`RateProviderError::Internal`]. Never a
+//! silent success.
+
+use bss_ledger_sdk::RateProviderError;
+use toolkit_http::HttpError;
+
+/// Map a `toolkit_http` transport error to the ledger's semantic rate error.
+///
+/// Note: a non-2xx status only surfaces as [`HttpError::HttpStatus`] when the
+/// caller uses a status-checking body reader (`.json()` / `.checked_bytes()`);
+/// the sources call plain `.send()` and inspect `response.status()` directly,
+/// mapping to [`RateProviderError::UpstreamStatus`] themselves.
+#[must_use]
+pub fn map_http_error(e: &HttpError) -> RateProviderError {
+    match e {
+        HttpError::Timeout(_) | HttpError::DeadlineExceeded(_) => {
+            RateProviderError::Unreachable(e.to_string())
+        }
+        HttpError::HttpStatus { status, .. } => RateProviderError::UpstreamStatus(status.as_u16()),
+        // `Transport` and `Tls` box an arbitrary inner error and forward its
+        // `Display` verbatim, so this text is not drawn from a closed set. It is
+        // kept because it is the only transport diagnostic an operator gets, and
+        // it cannot disclose a credential (both sources authenticate with a
+        // header). Callers log it at `debug`, not `warn` — see
+        // `fetch::fetch_and_parse`.
+        HttpError::Transport(_)
+        | HttpError::Tls(_)
+        | HttpError::Overloaded
+        | HttpError::ServiceClosed => RateProviderError::Unreachable(e.to_string()),
+        // `InvalidUri`'s `Display` embeds the raw request URL verbatim. A
+        // `base_url` may have an operator-embedded secret spliced into it (no
+        // source here supports query-string API-key auth), so never echo the
+        // URL itself into an error the sync job logs/alarms on — only the
+        // structured `kind` + diagnostic `reason`.
+        HttpError::InvalidUri { kind, reason, .. } => {
+            RateProviderError::Internal(format!("invalid request URL ({kind:?}): {reason}"))
+        }
+        // `HttpError` is `#[non_exhaustive]`; local faults and any future variant
+        // fall through here as an internal fault, never a silent success. A future
+        // variant could carry a URL in its `Display` the way `InvalidUri` does and
+        // this arm would forward it — which is why the caller's `warn` line uses
+        // the fixed kind label and this text only reaches `debug`. Give such a
+        // variant its own arm above rather than widening this one.
+        other => RateProviderError::Internal(other.to_string()),
+    }
+}
+
+/// Metric-label classification of a mapped [`RateProviderError`], for
+/// `FetchMetrics::incr_fetch_error`. Kept separate from the error's own
+/// `Display` so the metric label always reflects the *real* mapped kind,
+/// never a hardcoded guess made before `map_http_error` ran.
+#[must_use]
+pub fn error_kind_label(e: &RateProviderError) -> &'static str {
+    match e {
+        RateProviderError::PairUnavailable { .. } => "pair_unavailable",
+        RateProviderError::Unreachable(_) => "unreachable",
+        RateProviderError::UpstreamStatus(_) => "upstream_status",
+        RateProviderError::InvalidPair(_) => "invalid_pair",
+        RateProviderError::Internal(_) => "internal",
+    }
+}
+
+#[cfg(test)]
+#[path = "error_tests.rs"]
+mod tests;

--- a/gears/bss/rate-provider/rate-provider-sdk/src/error_tests.rs
+++ b/gears/bss/rate-provider/rate-provider-sdk/src/error_tests.rs
@@ -1,0 +1,88 @@
+//! Tests for the HTTP-to-domain error mapping.
+
+use std::time::Duration;
+
+use bss_ledger_sdk::RateProviderError;
+use toolkit_http::{HttpError, InvalidUriKind};
+
+use super::{error_kind_label, map_http_error};
+
+#[test]
+fn timeout_maps_to_unreachable() {
+    let mapped = map_http_error(&HttpError::Timeout(Duration::from_secs(5)));
+    assert!(matches!(mapped, RateProviderError::Unreachable(_)));
+}
+
+#[test]
+fn deadline_maps_to_unreachable() {
+    let mapped = map_http_error(&HttpError::DeadlineExceeded(Duration::from_secs(5)));
+    assert!(matches!(mapped, RateProviderError::Unreachable(_)));
+}
+
+#[test]
+fn overloaded_maps_to_unreachable() {
+    assert!(matches!(
+        map_http_error(&HttpError::Overloaded),
+        RateProviderError::Unreachable(_)
+    ));
+}
+
+#[test]
+fn http_status_maps_to_upstream_status() {
+    let mapped = map_http_error(&HttpError::HttpStatus {
+        status: http::StatusCode::SERVICE_UNAVAILABLE,
+        body_preview: String::new(),
+        content_type: None,
+        retry_after: None,
+    });
+    assert!(matches!(mapped, RateProviderError::UpstreamStatus(503)));
+}
+
+#[test]
+fn invalid_uri_maps_to_internal_and_never_echoes_the_raw_url() {
+    // A `base_url` may have an operator-embedded secret spliced into it (no
+    // source supports query-string auth) — the mapped error must never repeat
+    // the raw URL verbatim, only the structured `kind` + diagnostic `reason`.
+    let secret_url = "https://api.example.com/latest?access_key=SECRET123";
+    let mapped = map_http_error(&HttpError::InvalidUri {
+        url: secret_url.to_owned(),
+        kind: InvalidUriKind::ParseError,
+        reason: "unexpected character".to_owned(),
+    });
+    match mapped {
+        RateProviderError::Internal(msg) => {
+            assert!(
+                !msg.contains("SECRET123"),
+                "mapped error leaked the raw URL: {msg}"
+            );
+        }
+        other => panic!("expected Internal, got {other:?}"),
+    }
+}
+
+#[test]
+fn error_kind_label_reflects_the_mapped_variant_not_a_hardcoded_guess() {
+    assert_eq!(
+        error_kind_label(&RateProviderError::Unreachable("x".to_owned())),
+        "unreachable"
+    );
+    assert_eq!(
+        error_kind_label(&RateProviderError::UpstreamStatus(503)),
+        "upstream_status"
+    );
+    assert_eq!(
+        error_kind_label(&RateProviderError::Internal("x".to_owned())),
+        "internal"
+    );
+    assert_eq!(
+        error_kind_label(&RateProviderError::InvalidPair("x".to_owned())),
+        "invalid_pair"
+    );
+    assert_eq!(
+        error_kind_label(&RateProviderError::PairUnavailable {
+            base: "EUR".to_owned(),
+            quote: "USD".to_owned()
+        }),
+        "pair_unavailable"
+    );
+}

--- a/gears/bss/rate-provider/rate-provider-sdk/src/fetch.rs
+++ b/gears/bss/rate-provider/rate-provider-sdk/src/fetch.rs
@@ -1,0 +1,88 @@
+//! Shared instrumented HTTP GET + parse for every rate-provider source: timing,
+//! upstream-status, and fetch-error metrics, plus a `tracing` line on every
+//! failure branch. Error-kind labels are derived from the mapped
+//! [`RateProviderError`] (never a hardcoded guess made before the error is
+//! actually known).
+//!
+//! On the two transport branches the `warn` line carries only that fixed kind
+//! label and the error text is emitted at `debug`, so the level operators alert
+//! on has a bounded vocabulary — see [`crate::error::map_http_error`].
+
+use std::time::Instant;
+
+use bss_ledger_sdk::{ProviderRate, RateProviderError};
+use toolkit_http::RequestBuilder;
+
+use crate::error::{error_kind_label, map_http_error};
+use crate::metrics::FetchMetrics;
+
+/// Send `request`, then hand the response bytes to `parse`. `parse` returns the
+/// mapped rates plus the publication timestamp to record as the "last success"
+/// gauge — a *feed-freshness* signal (the document's own publication time), not
+/// wall-clock fetch time.
+///
+/// # Errors
+/// Propagates a transport failure ([`RateProviderError::Unreachable`] /
+/// [`RateProviderError::Internal`]), a non-2xx status
+/// ([`RateProviderError::UpstreamStatus`]), or whatever `parse` returns.
+pub async fn fetch_and_parse<F>(
+    request: RequestBuilder,
+    provider_id: &str,
+    metrics: &dyn FetchMetrics,
+    parse: F,
+) -> Result<Vec<ProviderRate>, RateProviderError>
+where
+    F: FnOnce(&[u8]) -> Result<(Vec<ProviderRate>, i64), RateProviderError>,
+{
+    let started = Instant::now();
+    let resp = request.send().await.map_err(|e| {
+        let mapped = map_http_error(&e);
+        let kind = error_kind_label(&mapped);
+        // `warn` carries only the fixed kind label; the transport text goes to
+        // `debug`. `HttpError::Transport`/`Tls` forward an arbitrary inner error's
+        // `Display`, and `HttpError` is `#[non_exhaustive]`, so the strings that
+        // can arrive here are not a closed set — the line an operator alerts on
+        // stays a bounded vocabulary. No credential can appear on either line:
+        // every source authenticates with a header, never a query string.
+        tracing::warn!(provider = provider_id, error_kind = kind, "rate-provider source: request failed");
+        tracing::debug!(provider = provider_id, error = %mapped, "rate-provider source: request failure detail");
+        metrics.incr_fetch_error(provider_id, kind);
+        mapped
+    })?;
+
+    let status = resp.status().as_u16();
+    metrics.incr_upstream_status(provider_id, status);
+    if !resp.status().is_success() {
+        tracing::warn!(
+            provider = provider_id,
+            status,
+            "rate-provider source: upstream returned a non-success status"
+        );
+        metrics.incr_fetch_error(provider_id, "upstream_status");
+        return Err(RateProviderError::UpstreamStatus(status));
+    }
+
+    let bytes = resp.bytes().await.map_err(|e| {
+        let mapped = map_http_error(&e);
+        let kind = error_kind_label(&mapped);
+        // Same split as the send branch above.
+        tracing::warn!(provider = provider_id, error_kind = kind, "rate-provider source: reading response body failed");
+        tracing::debug!(provider = provider_id, error = %mapped, "rate-provider source: body-read failure detail");
+        metrics.incr_fetch_error(provider_id, kind);
+        mapped
+    })?;
+
+    let (rates, as_of_unix) = parse(&bytes).inspect_err(|e| {
+        tracing::warn!(provider = provider_id, error = %e, "rate-provider source: parsing response body failed");
+        metrics.incr_fetch_error(provider_id, error_kind_label(e));
+    })?;
+
+    metrics.observe_fetch(provider_id, started.elapsed().as_secs_f64());
+    metrics.observe_rates_returned(provider_id, u64::try_from(rates.len()).unwrap_or(u64::MAX));
+    metrics.set_last_success(provider_id, as_of_unix);
+    Ok(rates)
+}
+
+#[cfg(test)]
+#[path = "fetch_tests.rs"]
+mod tests;

--- a/gears/bss/rate-provider/rate-provider-sdk/src/fetch_tests.rs
+++ b/gears/bss/rate-provider/rate-provider-sdk/src/fetch_tests.rs
@@ -1,0 +1,334 @@
+//! Tests for the shared instrumented fetch path's metrics contract: error-kind
+//! labels derived from the *mapped* error, an upstream-status count on every
+//! response, and `set_last_success` recording the feed's own publication time
+//! rather than wall-clock.
+//!
+//! Driven over a real in-process server: `fetch_and_parse` takes a live
+//! `RequestBuilder`, so there is no transport seam to fake.
+
+use std::sync::Mutex;
+use std::time::Duration;
+
+use axum::Router;
+use axum::http::StatusCode;
+use axum::routing::get;
+use bss_ledger_sdk::{ProviderRate, RateProviderError};
+use chrono::DateTime;
+use toolkit_http::HttpClient;
+
+use super::fetch_and_parse;
+use crate::metrics::FetchMetrics;
+
+const PROVIDER: &str = "ecb";
+
+/// The publication timestamp a successful `parse` reports — deliberately far in
+/// the past so it cannot be confused with a wall-clock reading.
+const AS_OF_UNIX: i64 = 1_700_000_000;
+
+/// One recorded metric call.
+#[derive(Debug, PartialEq)]
+enum Event {
+    Fetch { provider: String },
+    RatesReturned { provider: String, count: u64 },
+    FetchError { provider: String, kind: String },
+    LastSuccess { provider: String, unix_secs: i64 },
+    UpstreamStatus { provider: String, status: u16 },
+}
+
+/// Records every call so a test can assert which instruments fired, with which
+/// labels and values.
+#[derive(Default)]
+struct RecordingMetrics {
+    events: Mutex<Vec<Event>>,
+}
+
+impl RecordingMetrics {
+    fn events(&self) -> Vec<Event> {
+        std::mem::take(&mut *self.events.lock().unwrap())
+    }
+}
+
+impl FetchMetrics for RecordingMetrics {
+    fn observe_fetch(&self, provider: &str, _seconds: f64) {
+        self.events.lock().unwrap().push(Event::Fetch {
+            provider: provider.to_owned(),
+        });
+    }
+    fn observe_rates_returned(&self, provider: &str, count: u64) {
+        self.events.lock().unwrap().push(Event::RatesReturned {
+            provider: provider.to_owned(),
+            count,
+        });
+    }
+    fn incr_fetch_error(&self, provider: &str, kind: &str) {
+        self.events.lock().unwrap().push(Event::FetchError {
+            provider: provider.to_owned(),
+            kind: kind.to_owned(),
+        });
+    }
+    fn set_last_success(&self, provider: &str, unix_secs: i64) {
+        self.events.lock().unwrap().push(Event::LastSuccess {
+            provider: provider.to_owned(),
+            unix_secs,
+        });
+    }
+    fn incr_upstream_status(&self, provider: &str, status: u16) {
+        self.events.lock().unwrap().push(Event::UpstreamStatus {
+            provider: provider.to_owned(),
+            status,
+        });
+    }
+}
+
+/// Serve `body` with `status` on `/feed`, returning its URL.
+async fn spawn_server(status: u16, body: &'static str) -> (String, tokio::task::JoinHandle<()>) {
+    let app = Router::new().route(
+        "/feed",
+        get(move || async move { (StatusCode::from_u16(status).unwrap(), body) }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    (format!("http://{addr}/feed"), handle)
+}
+
+fn client() -> HttpClient {
+    HttpClient::builder()
+        .timeout(Duration::from_secs(2))
+        .build()
+        .unwrap()
+}
+
+/// What `fetch_and_parse`'s `parse` closure returns: the mapped rates plus the
+/// document's publication time.
+type ParseResult = Result<(Vec<ProviderRate>, i64), RateProviderError>;
+
+/// A `parse` that succeeds with `n` rates and the fixed publication time.
+fn parse_ok(n: usize) -> impl FnOnce(&[u8]) -> ParseResult {
+    move |_bytes| {
+        let rates = (0..n)
+            .map(|i| ProviderRate {
+                base: "EUR".to_owned(),
+                quote: format!("Q{i}"),
+                rate_micro: 1_000_000,
+                as_of: DateTime::from_timestamp(AS_OF_UNIX, 0).unwrap(),
+                provider: PROVIDER.to_owned(),
+            })
+            .collect();
+        Ok((rates, AS_OF_UNIX))
+    }
+}
+
+#[tokio::test]
+async fn success_records_status_duration_count_and_the_feeds_publication_time() {
+    let (url, _server) = spawn_server(200, "body").await;
+    let metrics = RecordingMetrics::default();
+    let rates = fetch_and_parse(client().get(&url), PROVIDER, &metrics, parse_ok(3))
+        .await
+        .unwrap();
+    assert_eq!(rates.len(), 3);
+
+    let events = metrics.events();
+    assert!(events.contains(&Event::UpstreamStatus {
+        provider: PROVIDER.to_owned(),
+        status: 200
+    }));
+    assert!(events.contains(&Event::Fetch {
+        provider: PROVIDER.to_owned()
+    }));
+    assert!(events.contains(&Event::RatesReturned {
+        provider: PROVIDER.to_owned(),
+        count: 3
+    }));
+    // The freshness gauge carries the DOCUMENT's publication time; wall-clock
+    // would make a stale feed look perpetually fresh.
+    assert!(events.contains(&Event::LastSuccess {
+        provider: PROVIDER.to_owned(),
+        unix_secs: AS_OF_UNIX
+    }));
+    assert!(
+        !events.iter().any(|e| matches!(e, Event::FetchError { .. })),
+        "a successful fetch must record no error: {events:?}"
+    );
+}
+
+#[tokio::test]
+async fn non_success_status_is_counted_and_labelled_upstream_status() {
+    let (url, _server) = spawn_server(503, "nope").await;
+    let metrics = RecordingMetrics::default();
+    let err = fetch_and_parse(client().get(&url), PROVIDER, &metrics, parse_ok(1))
+        .await
+        .unwrap_err();
+    assert!(matches!(err, RateProviderError::UpstreamStatus(503)));
+
+    let events = metrics.events();
+    assert!(events.contains(&Event::UpstreamStatus {
+        provider: PROVIDER.to_owned(),
+        status: 503
+    }));
+    assert!(events.contains(&Event::FetchError {
+        provider: PROVIDER.to_owned(),
+        kind: "upstream_status".to_owned()
+    }));
+    // A failed tick must not move the freshness gauge.
+    assert!(
+        !events
+            .iter()
+            .any(|e| matches!(e, Event::LastSuccess { .. })),
+        "a non-2xx response must not record a success: {events:?}"
+    );
+}
+
+#[tokio::test]
+async fn parse_failure_label_comes_from_the_returned_error_not_a_hardcoded_kind() {
+    // `parse` may return ANY `RateProviderError`, and the label must reflect the
+    // real variant so `fx_provider_fetch_errors_total{kind}` stays truthful.
+    let (url, _server) = spawn_server(200, "body").await;
+    let metrics = RecordingMetrics::default();
+    let err = fetch_and_parse(client().get(&url), PROVIDER, &metrics, |_bytes| {
+        Err(RateProviderError::InvalidPair("bad pair".to_owned()))
+    })
+    .await
+    .unwrap_err();
+    assert!(matches!(err, RateProviderError::InvalidPair(_)));
+
+    let events = metrics.events();
+    assert!(
+        events.contains(&Event::FetchError {
+            provider: PROVIDER.to_owned(),
+            kind: "invalid_pair".to_owned()
+        }),
+        "expected the mapped kind, got {events:?}"
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|e| matches!(e, Event::LastSuccess { .. })),
+        "a parse failure must not record a success: {events:?}"
+    );
+}
+
+#[tokio::test]
+async fn internal_parse_failure_is_labelled_internal() {
+    let (url, _server) = spawn_server(200, "body").await;
+    let metrics = RecordingMetrics::default();
+    let _err = fetch_and_parse(client().get(&url), PROVIDER, &metrics, |_bytes| {
+        Err(RateProviderError::Internal("bad xml".to_owned()))
+    })
+    .await
+    .unwrap_err();
+
+    assert!(metrics.events().contains(&Event::FetchError {
+        provider: PROVIDER.to_owned(),
+        kind: "internal".to_owned()
+    }));
+}
+
+#[tokio::test]
+async fn transport_failure_is_labelled_unreachable_and_records_no_status() {
+    // Bind then drop the listener: the port is free but nothing is listening, so
+    // the request fails before any response exists to count a status for.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    drop(listener);
+
+    let metrics = RecordingMetrics::default();
+    let err = fetch_and_parse(
+        client().get(&format!("http://{addr}/feed")),
+        PROVIDER,
+        &metrics,
+        parse_ok(1),
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(err, RateProviderError::Unreachable(_)));
+
+    let events = metrics.events();
+    assert!(events.contains(&Event::FetchError {
+        provider: PROVIDER.to_owned(),
+        kind: "unreachable".to_owned()
+    }));
+    assert!(
+        !events
+            .iter()
+            .any(|e| matches!(e, Event::UpstreamStatus { .. })),
+        "no response means no status to record: {events:?}"
+    );
+}
+
+#[tokio::test]
+async fn an_empty_but_valid_document_still_counts_as_a_success() {
+    // Whether an empty table is acceptable is each source's call (both reject it);
+    // the shared helper must not invent an error of its own.
+    let (url, _server) = spawn_server(200, "body").await;
+    let metrics = RecordingMetrics::default();
+    let rates = fetch_and_parse(client().get(&url), PROVIDER, &metrics, parse_ok(0))
+        .await
+        .unwrap();
+    assert!(rates.is_empty());
+
+    assert!(metrics.events().contains(&Event::RatesReturned {
+        provider: PROVIDER.to_owned(),
+        count: 0
+    }));
+}
+
+#[tokio::test]
+async fn a_reply_slower_than_the_configured_timeout_is_unreachable_not_a_hang() {
+    // The reachable-but-stalled upstream: a live listener that answers only
+    // after 2 s, against a 200 ms client timeout. Connection refusal (above)
+    // cannot represent this case — there the transport fails instantly, while
+    // here the request has to be cut off by the configured timeout.
+    // `HttpError::Timeout` maps to `Unreachable` (see `error::map_http_error`),
+    // and a timed-out attempt must move only the error instrument.
+    let app = Router::new().route(
+        "/feed",
+        get(|| async {
+            tokio::time::sleep(Duration::from_secs(2)).await;
+            "too late"
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let _server = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    let slow_client = HttpClient::builder()
+        .timeout(Duration::from_millis(200))
+        .build()
+        .unwrap();
+    let metrics = RecordingMetrics::default();
+    let err = fetch_and_parse(
+        slow_client.get(&format!("http://{addr}/feed")),
+        PROVIDER,
+        &metrics,
+        parse_ok(1),
+    )
+    .await
+    .unwrap_err();
+    assert!(
+        matches!(err, RateProviderError::Unreachable(_)),
+        "a timeout must map to Unreachable, got {err:?}"
+    );
+
+    let events = metrics.events();
+    assert!(events.contains(&Event::FetchError {
+        provider: PROVIDER.to_owned(),
+        kind: "unreachable".to_owned()
+    }));
+    // No response ever arrived, so there is no status to count and no success
+    // instrument may move — a timed-out feed must look failed, never fresh.
+    assert!(
+        !events.iter().any(|e| matches!(
+            e,
+            Event::UpstreamStatus { .. }
+                | Event::Fetch { .. }
+                | Event::RatesReturned { .. }
+                | Event::LastSuccess { .. }
+        )),
+        "a timed-out fetch must record only the error: {events:?}"
+    );
+}

--- a/gears/bss/rate-provider/rate-provider-sdk/src/gts.rs
+++ b/gears/bss/rate-provider/rate-provider-sdk/src/gts.rs
@@ -1,0 +1,22 @@
+//! GTS schema for FX rate-provider *source* plugins.
+//!
+//! Each source plugin (ECB, http-json, …) registers a `PluginV1` instance of this
+//! type with the types-registry; the core `bss-rate-provider` gear discovers them
+//! by querying instances of this type and orders them by `priority` (lower =
+//! tried first) to build the fallback composite.
+
+use toolkit_gts::{PluginV1, gts_type_schema};
+
+/// GTS type for a rate-provider source-plugin instance.
+///
+/// Instance ids look like
+/// `gts.cf.toolkit.plugins.plugin.v1~cf.bss.rate_provider_source.plugin.v1~<vendor>.<segment>`.
+#[derive(Default)]
+#[gts_type_schema(
+    dir_path = "schemas",
+    base = PluginV1,
+    type_id = gts_id!("cf.toolkit.plugins.plugin.v1~cf.bss.rate_provider_source.plugin.v1~"),
+    description = "FX rate-provider source plugin specification",
+    properties = "",
+)]
+pub struct RateProviderSourcePluginSpecV1;

--- a/gears/bss/rate-provider/rate-provider-sdk/src/http_client.rs
+++ b/gears/bss/rate-provider/rate-provider-sdk/src/http_client.rs
@@ -1,0 +1,74 @@
+//! Shared outbound HTTP client construction for rate-provider sources.
+
+use std::time::Duration;
+
+use http::Uri;
+use toolkit_http::HttpClient;
+
+/// Largest accepted per-attempt outbound timeout (30 s).
+///
+/// A ceiling, not a recommendation: the plugin defaults are 5 s. It exists to
+/// reject a misconfigured source that would stall a whole rate-sync pass — see
+/// [`build_source_http_client`].
+pub const MAX_TIMEOUT_MS: u64 = 30_000;
+
+/// Build the shared outbound HTTP client for a rate-provider source:
+/// TLS-only, a per-attempt timeout, `OTel`-instrumented. Validates `base_url` up
+/// front, so a misconfiguration fails at gear `init()` — never silently deferred
+/// to the first fetch.
+///
+/// The URL is parsed with the same [`Uri`] type `toolkit-http` uses on the request
+/// path, rather than string-matched, so this gate applies the upstream
+/// normalization rules: the scheme is compared **case-insensitively** (`Uri`
+/// canonicalizes it, so `HTTPS://host` is accepted) and a **host is required**
+/// (`https://` alone is not a usable endpoint).
+///
+/// A zero timeout is not "no timeout": it becomes a zero-duration per-attempt
+/// deadline that elapses before any connect can finish, so every request — and
+/// every retry — fails at the first fetch. That is the deferred failure this
+/// function exists to prevent, so it is rejected too.
+///
+/// The upper bound exists because the composite fetches sources **sequentially**,
+/// making the worst-case duration of one rate-sync pass the sum of every source's
+/// `timeout_ms`. That sum has to stay well under the ledger's rate-sync interval
+/// (1 h by default), or a pass overruns its schedule and refreshes are silently
+/// skipped. No single `init()` can check the real rule — the timeouts live in each
+/// source plugin's config, the interval in the ledger's — but this gate does catch
+/// the input that actually happens: a unit mix-up (seconds written into a
+/// milliseconds field) turning one source into a minutes-long stall.
+///
+/// `base_url` is never echoed into the returned error: it may have an
+/// operator-embedded secret spliced into it (no rate-provider source supports
+/// query-string API-key auth, only header-based auth).
+///
+/// # Errors
+/// An error if `base_url` is not a parseable URL, its scheme is not https, it
+/// carries no host, `timeout_ms` is zero or above [`MAX_TIMEOUT_MS`], or the
+/// underlying client fails to build.
+pub fn build_source_http_client(base_url: &str, timeout_ms: u64) -> anyhow::Result<HttpClient> {
+    // The parse error from `http` reports the malformation only, never the input.
+    let uri: Uri = base_url
+        .parse()
+        .map_err(|e| anyhow::anyhow!("base_url is not a valid URL: {e}"))?;
+    anyhow::ensure!(
+        uri.scheme_str() == Some("https"),
+        "base_url must use the https scheme"
+    );
+    anyhow::ensure!(uri.authority().is_some(), "base_url must include a host");
+    anyhow::ensure!(timeout_ms > 0, "timeout_ms must be greater than zero");
+    // The ceiling is named in the message so the operator can see the limit
+    // without reading this source.
+    anyhow::ensure!(
+        timeout_ms <= MAX_TIMEOUT_MS,
+        "timeout_ms must not exceed {MAX_TIMEOUT_MS} ms"
+    );
+    Ok(HttpClient::builder()
+        .deny_insecure_http()
+        .timeout(Duration::from_millis(timeout_ms))
+        .with_otel()
+        .build()?)
+}
+
+#[cfg(test)]
+#[path = "http_client_tests.rs"]
+mod tests;

--- a/gears/bss/rate-provider/rate-provider-sdk/src/http_client_tests.rs
+++ b/gears/bss/rate-provider/rate-provider-sdk/src/http_client_tests.rs
@@ -1,0 +1,172 @@
+//! Tests for the shared outbound-client gate: https-only with a host, a usable
+//! timeout, and never echoing the (possibly secret-bearing) `base_url` into the
+//! error.
+
+use super::{MAX_TIMEOUT_MS, build_source_http_client};
+
+// The accepting cases are async because building the client spawns a `tower`
+// buffer worker, which needs a live Tokio reactor. The rejection cases fail
+// validation before any client is built, so they stay plain `#[test]`.
+#[tokio::test]
+async fn https_base_url_builds() {
+    assert!(build_source_http_client("https://example.com/rates", 1000).is_ok());
+}
+
+#[tokio::test]
+async fn scheme_is_matched_case_insensitively() {
+    // A URI scheme is case-insensitive (RFC 3986 §3.1) and `http::Uri`
+    // canonicalizes it, so `toolkit-http`'s own TLS gate sees plain `https` and
+    // uses TLS. Rejecting these here would fail a configuration that works.
+    for url in [
+        "HTTPS://example.com/rates",
+        "HttPs://example.com/rates",
+        "Https://example.com/rates",
+    ] {
+        assert!(
+            build_source_http_client(url, 1000).is_ok(),
+            "{url:?} is valid https and must be accepted"
+        );
+    }
+}
+
+#[test]
+fn plain_http_is_rejected_at_build_time() {
+    // Validating at init rather than at first fetch: a plain-http
+    // misconfiguration must fail loudly instead of silently sending rates over
+    // cleartext. Upper-case too — casing must not bypass the scheme check.
+    for url in ["http://example.com/rates", "HTTP://example.com/rates"] {
+        assert!(
+            build_source_http_client(url, 1000).is_err(),
+            "{url:?} must be rejected"
+        );
+    }
+}
+
+#[test]
+fn other_schemes_are_rejected() {
+    for url in [
+        "ftp://example.com/rates",
+        "file:///etc/passwd",
+        "wss://example.com/rates",
+        // No scheme at all.
+        "example.com/rates",
+        "",
+    ] {
+        assert!(
+            build_source_http_client(url, 1000).is_err(),
+            "{url:?} must be rejected"
+        );
+    }
+}
+
+#[test]
+fn https_without_a_host_is_rejected() {
+    // The right scheme but no reachable authority, so not a usable endpoint.
+    for url in ["https://", "https:///rates", "https:/example.com"] {
+        assert!(
+            build_source_http_client(url, 1000).is_err(),
+            "{url:?} has no host and must be rejected"
+        );
+    }
+}
+
+// Async unlike the other rejection cases: if the zero-timeout gate is ever
+// removed, this test then reaches the client build, and a reactor keeps that
+// failure a clean assertion instead of a confusing "no reactor running" panic.
+#[tokio::test]
+async fn zero_timeout_is_rejected() {
+    // A zero `timeout_ms` is not "unlimited": it becomes a zero-duration
+    // per-attempt deadline that elapses before any connect completes, so every
+    // fetch (and every retry) fails at the first sync tick.
+    assert!(
+        build_source_http_client("https://example.com/rates", 0).is_err(),
+        "a zero timeout must be rejected"
+    );
+}
+
+#[tokio::test]
+async fn smallest_nonzero_timeout_is_accepted() {
+    // Above zero the lower end stays the operator's choice.
+    assert!(build_source_http_client("https://example.com/rates", 1).is_ok());
+}
+
+// The two tests below pin the ceiling as a pair: either alone would pass for an
+// arbitrary bound.
+#[tokio::test]
+async fn timeout_at_the_ceiling_is_accepted() {
+    assert!(
+        build_source_http_client("https://example.com/rates", MAX_TIMEOUT_MS).is_ok(),
+        "exactly MAX_TIMEOUT_MS must still build: the bound is inclusive"
+    );
+}
+
+#[tokio::test]
+async fn timeout_above_the_ceiling_is_rejected() {
+    // Sources are fetched sequentially, so one oversized timeout eats into the
+    // whole rate-sync pass. Both a hair past the ceiling and the realistic unit
+    // mix-up (seconds written into a milliseconds field) are rejected.
+    for timeout_ms in [MAX_TIMEOUT_MS + 1, 3_600_000] {
+        assert!(
+            build_source_http_client("https://example.com/rates", timeout_ms).is_err(),
+            "{timeout_ms} ms exceeds MAX_TIMEOUT_MS and must be rejected"
+        );
+    }
+}
+
+#[test]
+fn oversized_timeout_error_names_the_ceiling_and_not_the_url() {
+    // The operator has to learn the limit from the message; the message is
+    // logged, so it must still not repeat the (possibly secret-bearing) URL.
+    let secret_url = "https://api.example.com/latest?access_key=SECRET123";
+    let Err(err) = build_source_http_client(secret_url, MAX_TIMEOUT_MS + 1) else {
+        panic!("an oversized timeout must be rejected");
+    };
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains(&MAX_TIMEOUT_MS.to_string()),
+        "error must name the ceiling: {msg}"
+    );
+    assert!(
+        !msg.contains("SECRET123") && !msg.contains("api.example.com"),
+        "error leaked the URL: {msg}"
+    );
+}
+
+#[test]
+fn rejection_error_never_echoes_the_url() {
+    // A `base_url` may carry an operator-embedded credential; the error is logged
+    // by the sync job, so it must not repeat the URL verbatim. (`HttpClient` isn't
+    // `Debug`, so unwrap the error by matching, not `unwrap_err`.)
+    let secret_url = "http://api.example.com/latest?access_key=SECRET123";
+    let Err(err) = build_source_http_client(secret_url, 1000) else {
+        panic!("plain http must be rejected");
+    };
+    let msg = format!("{err:#}");
+    assert!(
+        !msg.contains("SECRET123"),
+        "error leaked the credential: {msg}"
+    );
+    assert!(
+        !msg.contains("api.example.com"),
+        "error leaked the host: {msg}"
+    );
+}
+
+#[test]
+fn unparseable_url_error_never_echoes_the_url() {
+    // The parse-failure path formats the underlying `http` error, so cover it
+    // separately from the scheme-rejection path above.
+    let secret_url = "ht tp://api.example.com/latest?access_key=SECRET123";
+    let Err(err) = build_source_http_client(secret_url, 1000) else {
+        panic!("a malformed URL must be rejected");
+    };
+    let msg = format!("{err:#}");
+    assert!(
+        !msg.contains("SECRET123"),
+        "error leaked the credential: {msg}"
+    );
+    assert!(
+        !msg.contains("api.example.com"),
+        "error leaked the host: {msg}"
+    );
+}

--- a/gears/bss/rate-provider/rate-provider-sdk/src/lib.rs
+++ b/gears/bss/rate-provider/rate-provider-sdk/src/lib.rs
@@ -1,0 +1,27 @@
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+//! `bss-rate-provider-sdk` — the FX rate-provider source-plugin contract.
+//!
+//! Defines the GTS plugin spec [`gts::RateProviderSourcePluginSpecV1`] that a
+//! rate-provider *source* plugin (ECB, http-json, …) registers as a `PluginV1`
+//! instance in the types-registry, and the shared utilities every rate-provider
+//! plugin gear needs: exact-decimal [`conversion`], HTTP-to-domain [`error`]
+//! mapping, the [`metrics`] fetch-metrics seam, a shared [`http_client`]
+//! constructor, an instrumented [`fetch`] helper, the [`publication_time`]
+//! guard on a feed's own `as_of`, and the shared [`registration`] sequence every
+//! plugin gear's `init()` performs.
+//!
+//! A source plugin registers `register_scoped::<dyn bss_ledger_sdk::RateProviderV1>`
+//! keyed by its GTS instance id; the core `bss-rate-provider` gear discovers the
+//! instances, orders them by `priority`, and composes them.
+
+pub mod conversion;
+pub mod currency;
+pub mod error;
+pub mod fetch;
+pub mod gts;
+pub mod http_client;
+pub mod metrics;
+pub mod publication_time;
+pub mod registration;
+
+pub use gts::RateProviderSourcePluginSpecV1;

--- a/gears/bss/rate-provider/rate-provider-sdk/src/metrics.rs
+++ b/gears/bss/rate-provider/rate-provider-sdk/src/metrics.rs
@@ -1,0 +1,145 @@
+//! The adapter's own fetch-metrics seam, shared by every source plugin.
+//!
+//! The fetch happens inside the source, out of the ledger's sight, so this owns
+//! its metrics. A port trait keeps sources decoupled from `OTel`: unit tests use
+//! [`NoopFetchMetrics`]; production wires [`OtelFetchMetrics`]. The `{provider}`
+//! label is the source `provider_id`.
+
+use std::sync::Arc;
+
+use opentelemetry::KeyValue;
+use opentelemetry::metrics::{Counter, Gauge, Histogram, Meter};
+
+/// Records per-source fetch instruments. All methods are cheap and infallible.
+pub trait FetchMetrics: Send + Sync {
+    /// Fetch+parse latency (`fx_provider_fetch_duration_seconds{provider}`).
+    fn observe_fetch(&self, provider: &str, seconds: f64);
+    /// Pairs returned by a successful fetch (`fx_provider_rates_returned{provider}`).
+    fn observe_rates_returned(&self, provider: &str, count: u64);
+    /// Fetch failure by error kind (`fx_provider_fetch_errors_total{provider,kind}`).
+    fn incr_fetch_error(&self, provider: &str, kind: &str);
+    /// Publication time of the last successfully served document
+    /// (`fx_provider_last_success_timestamp{provider}`).
+    ///
+    /// The value is the feed's own `as_of`, NOT wall-clock fetch time, so this
+    /// measures how old the *data* is — never how long since the job last ran.
+    /// A date-only feed like ECB reads hours behind on a healthy deployment and
+    /// days behind over a weekend, so an alert on `time() - this` must be
+    /// thresholded against the feed's publication cadence. Job liveness is a
+    /// different question, answered by whether a fetch was attempted at all
+    /// (`fx_provider_fetch_duration_seconds` / `fx_provider_fetch_errors_total`).
+    fn set_last_success(&self, provider: &str, unix_secs: i64);
+    /// Upstream HTTP status distribution (`fx_provider_upstream_status_total{provider,status}`).
+    fn incr_upstream_status(&self, provider: &str, status: u16);
+}
+
+/// Shared handle type the sources hold.
+pub type SharedFetchMetrics = Arc<dyn FetchMetrics>;
+
+/// No-op sink: the safe default before an exporter is wired, and for unit tests.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NoopFetchMetrics;
+
+impl FetchMetrics for NoopFetchMetrics {
+    fn observe_fetch(&self, _provider: &str, _seconds: f64) {}
+    fn observe_rates_returned(&self, _provider: &str, _count: u64) {}
+    fn incr_fetch_error(&self, _provider: &str, _kind: &str) {}
+    fn set_last_success(&self, _provider: &str, _unix_secs: i64) {}
+    fn incr_upstream_status(&self, _provider: &str, _status: u16) {}
+}
+
+/// Instrumentation scope name (matches the gear/subsystem name).
+const METER_NAME: &str = "bss-rate-provider";
+
+/// `OTel`-backed fetch metrics. Instruments carry full literal Prometheus names
+/// (counters end `_total`, the duration histogram `_seconds`); no `.with_unit()`,
+/// matching the collector's `add_metric_suffixes: false` convention.
+pub struct OtelFetchMetrics {
+    fetch_duration: Histogram<f64>,
+    rates_returned: Histogram<f64>,
+    fetch_errors: Counter<u64>,
+    last_success: Gauge<i64>,
+    upstream_status: Counter<u64>,
+}
+
+impl OtelFetchMetrics {
+    /// Build all instruments from a meter.
+    #[must_use]
+    pub fn new(meter: &Meter) -> Self {
+        Self {
+            fetch_duration: meter
+                .f64_histogram("fx_provider_fetch_duration_seconds")
+                .with_description("Outbound fetch+parse latency, seconds")
+                .with_boundaries(vec![0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0])
+                .build(),
+            rates_returned: meter
+                .f64_histogram("fx_provider_rates_returned")
+                .with_description("Pairs returned per successful fetch")
+                .build(),
+            fetch_errors: meter
+                .u64_counter("fx_provider_fetch_errors_total")
+                .with_description("Fetch failures by RateProviderError kind")
+                .build(),
+            last_success: meter
+                .i64_gauge("fx_provider_last_success_timestamp")
+                .with_description(
+                    "Publication time (the feed's own as_of) of the last served document, \
+                     not the time it was fetched",
+                )
+                .build(),
+            upstream_status: meter
+                .u64_counter("fx_provider_upstream_status_total")
+                .with_description("Upstream HTTP status distribution")
+                .build(),
+        }
+    }
+
+    /// Build against the process-global meter provider (a no-op until the host
+    /// wires an exporter, so this is always cheap and safe to call at `init()`).
+    #[must_use]
+    pub fn from_global() -> Self {
+        Self::new(&opentelemetry::global::meter(METER_NAME))
+    }
+}
+
+impl FetchMetrics for OtelFetchMetrics {
+    fn observe_fetch(&self, provider: &str, seconds: f64) {
+        self.fetch_duration
+            .record(seconds, &[KeyValue::new("provider", provider.to_owned())]);
+    }
+    fn observe_rates_returned(&self, provider: &str, count: u64) {
+        #[allow(
+            clippy::cast_precision_loss,
+            reason = "pair counts are tiny (tens); f64 represents them exactly"
+        )]
+        let count_f64 = count as f64;
+        self.rates_returned
+            .record(count_f64, &[KeyValue::new("provider", provider.to_owned())]);
+    }
+    fn incr_fetch_error(&self, provider: &str, kind: &str) {
+        self.fetch_errors.add(
+            1,
+            &[
+                KeyValue::new("provider", provider.to_owned()),
+                KeyValue::new("kind", kind.to_owned()),
+            ],
+        );
+    }
+    fn set_last_success(&self, provider: &str, unix_secs: i64) {
+        self.last_success
+            .record(unix_secs, &[KeyValue::new("provider", provider.to_owned())]);
+    }
+    fn incr_upstream_status(&self, provider: &str, status: u16) {
+        self.upstream_status.add(
+            1,
+            &[
+                KeyValue::new("provider", provider.to_owned()),
+                KeyValue::new("status", i64::from(status)),
+            ],
+        );
+    }
+}
+
+#[cfg(test)]
+#[path = "metrics_tests.rs"]
+mod tests;

--- a/gears/bss/rate-provider/rate-provider-sdk/src/metrics_tests.rs
+++ b/gears/bss/rate-provider/rate-provider-sdk/src/metrics_tests.rs
@@ -1,0 +1,182 @@
+//! Metrics tests: export the recorded instruments through an in-memory reader and
+//! assert the real names, label sets, and values — a rename, a dropped label, or a
+//! wrong value must all fail here.
+
+use opentelemetry::metrics::MeterProvider;
+use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData, ResourceMetrics};
+use opentelemetry_sdk::metrics::in_memory_exporter::InMemoryMetricExporter;
+use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
+
+use super::{FetchMetrics, OtelFetchMetrics};
+
+const PROVIDER: &str = "ecb";
+
+/// Record one call against every instrument, then flush and return the export.
+fn record_and_export() -> ResourceMetrics {
+    let exporter = InMemoryMetricExporter::default();
+    let provider = SdkMeterProvider::builder()
+        .with_reader(PeriodicReader::builder(exporter.clone()).build())
+        .build();
+
+    let metrics = OtelFetchMetrics::new(&provider.meter("test"));
+    metrics.observe_fetch(PROVIDER, 0.12);
+    metrics.observe_rates_returned(PROVIDER, 31);
+    metrics.incr_fetch_error(PROVIDER, "unreachable");
+    metrics.incr_upstream_status(PROVIDER, 503);
+    metrics.set_last_success(PROVIDER, 1_753_000_000);
+
+    provider.force_flush().unwrap();
+    exporter
+        .get_finished_metrics()
+        .unwrap()
+        .pop()
+        .expect("one export batch")
+}
+
+/// All instrument names present in the export.
+fn instrument_names(rm: &ResourceMetrics) -> Vec<String> {
+    rm.scope_metrics()
+        .flat_map(|sm| sm.metrics().map(|m| m.name().to_owned()))
+        .collect()
+}
+
+/// Every attribute `key=value` pair recorded for `instrument`.
+fn attributes_of(rm: &ResourceMetrics, instrument: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    for sm in rm.scope_metrics() {
+        for m in sm.metrics().filter(|m| m.name() == instrument) {
+            match m.data() {
+                AggregatedMetrics::U64(MetricData::Sum(sum)) => {
+                    for dp in sum.data_points() {
+                        for kv in dp.attributes() {
+                            out.push(format!("{}={}", kv.key, kv.value.as_str()));
+                        }
+                    }
+                }
+                AggregatedMetrics::I64(MetricData::Gauge(gauge)) => {
+                    for dp in gauge.data_points() {
+                        for kv in dp.attributes() {
+                            out.push(format!("{}={}", kv.key, kv.value.as_str()));
+                        }
+                    }
+                }
+                AggregatedMetrics::F64(MetricData::Histogram(hist)) => {
+                    for dp in hist.data_points() {
+                        for kv in dp.attributes() {
+                            out.push(format!("{}={}", kv.key, kv.value.as_str()));
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    out
+}
+
+#[test]
+fn exports_the_documented_prometheus_instrument_names() {
+    // These names are the scrape contract dashboards and alerts are written
+    // against (counters end `_total`, the duration histogram `_seconds`), so a
+    // rename is a breaking change.
+    let rm = record_and_export();
+    let names = instrument_names(&rm);
+    for expected in [
+        "fx_provider_fetch_duration_seconds",
+        "fx_provider_rates_returned",
+        "fx_provider_fetch_errors_total",
+        "fx_provider_last_success_timestamp",
+        "fx_provider_upstream_status_total",
+    ] {
+        assert!(
+            names.iter().any(|n| n == expected),
+            "missing instrument {expected}; exported: {names:?}"
+        );
+    }
+}
+
+#[test]
+fn every_instrument_carries_the_provider_label() {
+    let rm = record_and_export();
+    for instrument in [
+        "fx_provider_fetch_duration_seconds",
+        "fx_provider_rates_returned",
+        "fx_provider_fetch_errors_total",
+        "fx_provider_last_success_timestamp",
+        "fx_provider_upstream_status_total",
+    ] {
+        let attrs = attributes_of(&rm, instrument);
+        assert!(
+            attrs.iter().any(|a| a == "provider=ecb"),
+            "{instrument} is missing the provider label; got {attrs:?}"
+        );
+    }
+}
+
+#[test]
+fn fetch_errors_are_broken_down_by_kind() {
+    // Without the `kind` label the error dashboard collapses into one line.
+    let rm = record_and_export();
+    let attrs = attributes_of(&rm, "fx_provider_fetch_errors_total");
+    assert!(
+        attrs.iter().any(|a| a == "kind=unreachable"),
+        "expected kind=unreachable, got {attrs:?}"
+    );
+}
+
+#[test]
+fn upstream_statuses_are_broken_down_by_status() {
+    let rm = record_and_export();
+    let attrs = attributes_of(&rm, "fx_provider_upstream_status_total");
+    assert!(
+        attrs.iter().any(|a| a == "status=503"),
+        "expected status=503, got {attrs:?}"
+    );
+}
+
+#[test]
+fn recorded_values_reach_the_exporter_unchanged() {
+    let rm = record_and_export();
+    let mut checked_counter = false;
+    let mut checked_gauge = false;
+    for sm in rm.scope_metrics() {
+        for m in sm.metrics() {
+            match (m.name(), m.data()) {
+                ("fx_provider_fetch_errors_total", AggregatedMetrics::U64(MetricData::Sum(s))) => {
+                    for dp in s.data_points() {
+                        assert_eq!(dp.value(), 1, "one error was recorded");
+                        checked_counter = true;
+                    }
+                }
+                (
+                    "fx_provider_last_success_timestamp",
+                    AggregatedMetrics::I64(MetricData::Gauge(g)),
+                ) => {
+                    for dp in g.data_points() {
+                        assert_eq!(
+                            dp.value(),
+                            1_753_000_000,
+                            "the freshness gauge must export the exact unix time given"
+                        );
+                        checked_gauge = true;
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    assert!(checked_counter, "error counter was not exported");
+    assert!(checked_gauge, "last-success gauge was not exported");
+}
+
+#[test]
+fn from_global_records_without_panicking() {
+    // The production constructor runs against the process-global provider, which
+    // is a no-op until the host wires an exporter — safe to call at gear init().
+    let m = OtelFetchMetrics::from_global();
+    m.observe_fetch(PROVIDER, 0.12);
+    m.incr_fetch_error(PROVIDER, "unreachable");
+    m.incr_upstream_status(PROVIDER, 503);
+    m.set_last_success(PROVIDER, 1_753_000_000);
+    m.observe_rates_returned(PROVIDER, 31);
+}

--- a/gears/bss/rate-provider/rate-provider-sdk/src/publication_time.rs
+++ b/gears/bss/rate-provider/rate-provider-sdk/src/publication_time.rs
@@ -1,0 +1,68 @@
+//! Guard on a fetched document's own publication timestamp.
+//!
+//! The ledger decides whether a stored rate may still be used by its **age** —
+//! `now - as_of` against a staleness window. That check only protects against
+//! timestamps in the past. A document dated in the future has a negative age, so
+//! it reads as permanently fresh: a feed that published `as_of` a month ahead
+//! would keep the ledger posting at that rate long after the real one moved, and
+//! no staleness alarm would fire.
+//!
+//! Validation belongs to the **source plugin**, not the ledger: by then a rate is
+//! just a row in the store, and the ledger cannot tell "the feed published a bad
+//! timestamp" apart from "we have not synced in a while". Rejecting here is also
+//! fail-safe — the document becomes an `Err`, so the composite falls through to
+//! the next source instead of storing the bad value.
+
+use bss_ledger_sdk::RateProviderError;
+use chrono::{DateTime, TimeDelta, Utc};
+
+/// How far ahead of our own clock a publication timestamp may legitimately sit.
+///
+/// Derived from the two ways an honest feed can read "ahead" of us:
+///
+/// - **14 h — timezone.** A date-only feed (ECB publishes `2026-07-30`, no time)
+///   is anchored at 00:00:00 UTC by its plugin. If the publisher's civil date is
+///   ahead of UTC's, that anchor can land ahead of our clock; UTC+14 (Kiritimati)
+///   is the widest civil offset in use.
+/// - **12 h — host clock drift.** A generous allowance for a badly-synchronised
+///   host, so a local NTP failure degrades into wrong-but-served rather than a
+///   feed-wide outage.
+///
+/// 26 h is permissive enough that no correctly-published document is rejected,
+/// while still catching a timestamp far enough ahead to outlive the ledger's
+/// staleness window.
+pub const MAX_FUTURE_SKEW_HOURS: i64 = 26;
+
+/// Reject a document whose publication time runs more than
+/// [`MAX_FUTURE_SKEW_HOURS`] ahead of `now`.
+///
+/// `now` is a parameter rather than an internal `Utc::now()` so the bound is
+/// directly testable; callers on the fetch path pass `Utc::now()`.
+///
+/// # Errors
+/// [`RateProviderError::Internal`] naming both timestamps when `as_of` is beyond
+/// the bound — matching every other parse-stage rejection in the source plugins,
+/// and keeping a misbehaving feed visible on `fx_provider_fetch_errors_total`.
+pub fn reject_future_publication_time(
+    as_of: DateTime<Utc>,
+    now: DateTime<Utc>,
+    provider_id: &str,
+) -> Result<(), RateProviderError> {
+    let bound = now + TimeDelta::hours(MAX_FUTURE_SKEW_HOURS);
+    if as_of <= bound {
+        return Ok(());
+    }
+    tracing::warn!(
+        provider = provider_id,
+        as_of = %as_of,
+        bound = %bound,
+        "rate-provider source: rejecting a document published beyond the accepted clock skew"
+    );
+    Err(RateProviderError::Internal(format!(
+        "publication time {as_of} is more than {MAX_FUTURE_SKEW_HOURS}h ahead of {now}"
+    )))
+}
+
+#[cfg(test)]
+#[path = "publication_time_tests.rs"]
+mod tests;

--- a/gears/bss/rate-provider/rate-provider-sdk/src/publication_time_tests.rs
+++ b/gears/bss/rate-provider/rate-provider-sdk/src/publication_time_tests.rs
@@ -1,0 +1,63 @@
+//! Tests for the future-publication-time bound. The interesting cases are at the
+//! edge: the guard has to let a whole day of legitimate timezone/clock spread
+//! through, so the accept and reject cases are paired to pin the real value.
+
+use chrono::{DateTime, TimeDelta, Utc};
+
+use super::{MAX_FUTURE_SKEW_HOURS, reject_future_publication_time};
+
+const PROVIDER: &str = "ecb";
+
+/// A fixed "now" — no wall-clock reads, so the assertions cannot drift.
+fn now() -> DateTime<Utc> {
+    "2026-07-30T12:00:00Z".parse().unwrap()
+}
+
+#[test]
+fn a_past_publication_time_is_accepted() {
+    // The normal case: ECB dates the document earlier the same day.
+    let as_of = now() - TimeDelta::hours(12);
+    assert!(reject_future_publication_time(as_of, now(), PROVIDER).is_ok());
+}
+
+#[test]
+fn a_very_old_publication_time_is_still_accepted_here() {
+    // Age is the LEDGER's staleness rule, not this guard's. Rejecting an old
+    // document here would silently duplicate that policy in the wrong layer.
+    let as_of = now() - TimeDelta::days(400);
+    assert!(reject_future_publication_time(as_of, now(), PROVIDER).is_ok());
+}
+
+#[test]
+fn a_publication_time_exactly_at_the_bound_is_accepted() {
+    let as_of = now() + TimeDelta::hours(MAX_FUTURE_SKEW_HOURS);
+    assert!(
+        reject_future_publication_time(as_of, now(), PROVIDER).is_ok(),
+        "the bound is inclusive; a document exactly at it must still serve"
+    );
+}
+
+#[test]
+fn one_second_past_the_bound_is_rejected() {
+    let as_of = now() + TimeDelta::hours(MAX_FUTURE_SKEW_HOURS) + TimeDelta::seconds(1);
+    assert!(reject_future_publication_time(as_of, now(), PROVIDER).is_err());
+}
+
+#[test]
+fn a_day_ahead_is_accepted_so_a_date_only_feed_never_breaks() {
+    // A date-only feed anchored at 00:00:00 UTC can legitimately read a full day
+    // ahead of a host whose clock sits just before the rollover.
+    let as_of = now() + TimeDelta::hours(24);
+    assert!(reject_future_publication_time(as_of, now(), PROVIDER).is_ok());
+}
+
+#[test]
+fn a_far_future_document_is_rejected_without_echoing_anything_but_timestamps() {
+    let as_of = now() + TimeDelta::days(30);
+    let err = reject_future_publication_time(as_of, now(), PROVIDER).unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("2026-08-29"),
+        "the rejection must name the offending timestamp: {msg}"
+    );
+}

--- a/gears/bss/rate-provider/rate-provider-sdk/src/registration.rs
+++ b/gears/bss/rate-provider/rate-provider-sdk/src/registration.rs
@@ -1,0 +1,69 @@
+//! Shared `PluginV1<Spec>` registration for every rate-provider plugin gear —
+//! the source plugins (`RateProviderSourcePluginSpecV1`) and the core
+//! composite gear (`bss_ledger_sdk::RateProviderPluginSpecV1`) all publish a
+//! `PluginV1` instance and a scoped `RateProviderV1` client the same way.
+
+use std::sync::Arc;
+
+use bss_ledger_sdk::RateProviderV1;
+use toolkit::client_hub::ClientScope;
+use toolkit::context::GearCtx;
+use toolkit::gts::PluginV1;
+use types_registry_sdk::{RegisterResult, TypesRegistryClient};
+
+/// Register a `PluginV1<Spec>` instance in types-registry, then register the
+/// scoped `RateProviderV1` client the discoverer resolves via the returned
+/// instance id. Returns the instance id (for the caller's own log line).
+///
+/// # Errors
+/// Propagates types-registry unavailability, a registration rejection (e.g. a
+/// malformed `instance_segment`), or a partial-batch registration failure.
+pub async fn register_rate_provider_plugin<Spec>(
+    ctx: &GearCtx,
+    instance_segment: &str,
+    vendor: impl Into<String>,
+    priority: i16,
+    provider: Arc<dyn RateProviderV1>,
+) -> anyhow::Result<String>
+where
+    Spec: gts::GtsSchema + gts::GtsSerialize + Default,
+{
+    let (instance_id, instance_json) =
+        PluginV1::<Spec>::build_registration(instance_segment, vendor, priority)?;
+
+    let registry = ctx.client_hub().get::<dyn TypesRegistryClient>()?;
+    let results = registry.register(vec![instance_json]).await?;
+    RegisterResult::ensure_all_ok(&results)?;
+
+    ctx.client_hub()
+        .register_scoped::<dyn RateProviderV1>(ClientScope::gts_id(&instance_id), provider);
+
+    Ok(instance_id.to_string())
+}
+
+/// Test helper: assert a `PluginV1<Spec>` built for `instance_segment` parses
+/// as a valid GTS id. Shared by every rate-provider plugin gear's
+/// `gts_id_tests` module.
+///
+/// # Panics
+/// Panics if `build_registration` fails, or the built id fails GTS parsing —
+/// intended for use inside `#[test]` functions only.
+#[allow(
+    clippy::expect_used,
+    reason = "test-only helper: panicking here is exactly a failed assertion in the caller's #[test] fn"
+)]
+pub fn assert_registration_builds_valid_gts_id<Spec>(
+    instance_segment: &str,
+    vendor: &str,
+    priority: i16,
+) where
+    Spec: gts::GtsSchema + gts::GtsSerialize + Default,
+{
+    let (id, _json) = PluginV1::<Spec>::build_registration(instance_segment, vendor, priority)
+        .expect("build_registration should succeed for a well-formed instance segment");
+    assert!(
+        gts::GtsId::try_new(id.as_ref()).is_ok(),
+        "instance id is not a valid GTS id: {}",
+        id.as_ref()
+    );
+}

--- a/gears/bss/rate-provider/rate-provider/Cargo.toml
+++ b/gears/bss/rate-provider/rate-provider/Cargo.toml
@@ -1,0 +1,51 @@
+[package]
+name = "bss-rate-provider"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+description = "BSS FX rate-provider core gear: discovers + composes source plugins and registers the composite as a RateProviderV1 plugin the ledger resolves"
+
+[lints]
+workspace = true
+
+[dependencies]
+# The source-plugin GTS spec discovered via types-registry.
+bss-rate-provider-sdk = { workspace = true }
+# The RateProviderV1 contract + the composite-plugin GTS spec the ledger discovers.
+bss-ledger-sdk = { workspace = true }
+# Plugin discovery + registration.
+types-registry-sdk = { workspace = true }
+# The `deps = [types_registry]` gear-macro edge re-exports `::types_registry`, so
+# the gear crate must be a direct dependency (init-ordering; not used in code).
+types-registry = { workspace = true }
+# Gear macro, GearCtx, ClientHub/ClientScope, gts::PluginV1, config.
+toolkit = { workspace = true }
+# `#[domain_model]` on the domain-layer composite (DE0309 requires it, and it
+# compile-time-proves no infrastructure type leaked into that layer).
+toolkit-macros = { workspace = true }
+# SecurityContext in the fetch_latest signature.
+toolkit-security = { workspace = true }
+# inventory::submit! emitted by the gear macro.
+inventory = { workspace = true }
+
+async-trait = { workspace = true }
+anyhow = { workspace = true }
+tracing = { workspace = true }
+serde = { workspace = true }
+# Reads vendor/priority off the PluginV1 instance JSON during discovery.
+serde_json = { workspace = true }
+# async fn signatures + the macros/rt for tests.
+tokio = { workspace = true }
+
+[dev-dependencies]
+# `DateTime::from_timestamp` in the composite fallback tests.
+chrono = { workspace = true }
+# Integration test (tests/discovery.rs): drive DiscoveringRateProvider over a real
+# ClientHub + an in-memory types-registry mock with fake scoped source plugins.
+tokio = { workspace = true }
+async-trait = { workspace = true }
+bss-ledger-sdk = { workspace = true }
+bss-rate-provider-sdk = { workspace = true }
+toolkit = { workspace = true }
+toolkit-security = { workspace = true }
+types-registry-sdk = { workspace = true, features = ["test-util"] }

--- a/gears/bss/rate-provider/rate-provider/src/config.rs
+++ b/gears/bss/rate-provider/rate-provider/src/config.rs
@@ -1,0 +1,37 @@
+//! Core gear configuration.
+//!
+//! The core gear composes the registered source plugins (filtered by
+//! `source_vendor`) and re-registers the composite as a rate-provider plugin the
+//! ledger discovers (advertised under `vendor` + `priority`).
+
+use serde::Deserialize;
+
+/// Config for the core `bss-rate-provider` gear (`config:` block).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct RateProviderConfig {
+    /// Vendor this composite advertises for the ledger's plugin selection.
+    pub vendor: String,
+    /// Priority of this composite instance (lower preferred if several exist).
+    pub priority: i16,
+    /// Vendor used to select which SOURCE plugins this gear composes.
+    pub source_vendor: String,
+    /// Id reported by `provider_id()` before the first successful discovery
+    /// (never `"none"`, the ledger's unconfigured sentinel).
+    pub id: String,
+}
+
+impl Default for RateProviderConfig {
+    fn default() -> Self {
+        Self {
+            vendor: "cf.bss".to_owned(),
+            priority: 100,
+            source_vendor: "cf.bss".to_owned(),
+            id: "bss-rate-provider".to_owned(),
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "config_tests.rs"]
+mod tests;

--- a/gears/bss/rate-provider/rate-provider/src/config_tests.rs
+++ b/gears/bss/rate-provider/rate-provider/src/config_tests.rs
@@ -1,0 +1,28 @@
+//! Default-configuration tests.
+//!
+//! An empty `config:` block deploys the core gear entirely on these defaults, and
+//! three of the four have to agree with something outside this crate — so they are
+//! part of the contract, not internal detail.
+
+use super::RateProviderConfig;
+
+#[test]
+fn defaults_line_up_with_the_ledger_and_the_source_plugins() {
+    let cfg = RateProviderConfig::default();
+    // `vendor` is what the ledger's `fx.provider_vendor` must match to resolve
+    // this composite; `source_vendor` is what each source plugin's own `vendor`
+    // must match for this gear to compose it. Both sides ship "cf.bss", so an
+    // all-defaults deployment wires up end to end with no configuration at all.
+    assert_eq!(cfg.vendor, "cf.bss");
+    assert_eq!(cfg.source_vendor, "cf.bss");
+    assert_eq!(cfg.priority, 100);
+    assert_eq!(cfg.id, "bss-rate-provider");
+}
+
+#[test]
+fn the_default_id_is_not_the_ledgers_unconfigured_sentinel() {
+    // The ledger treats `provider_id() == "none"` as "no adapter wired" and stays
+    // silent on a fetch failure instead of alarming. A default of "none" here
+    // would therefore turn every outage of a *deployed* adapter into silence.
+    assert_ne!(RateProviderConfig::default().id, "none");
+}

--- a/gears/bss/rate-provider/rate-provider/src/domain/composite.rs
+++ b/gears/bss/rate-provider/rate-provider/src/domain/composite.rs
@@ -1,0 +1,116 @@
+//! `CompositeRateProvider` — ordered fallback over the discovered source
+//! plugins. Tries its ordered sources and returns the FIRST whole successful
+//! document (never a merge).
+//!
+//! Provenance is NOT tracked here. Each source stamps its own id onto every
+//! [`ProviderRate`] it returns, so the serving upstream travels with the data
+//! and the ledger records it per row.
+//!
+//! `provider_id()` is the composite's own constant identity, never "whoever
+//! served last": it carries no information about which `fetch_latest` it
+//! relates to, and the composite is registered process-wide in `ClientHub`, so
+//! a second consumer fetching in between would make the ledger stamp the wrong
+//! source onto financial records.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use bss_ledger_sdk::{CurrencyPair, ProviderRate, RateProviderError, RateProviderV1};
+use toolkit_macros::domain_model;
+use toolkit_security::SecurityContext;
+
+/// Ordered composite over one-or-more source plugins.
+///
+/// A domain type: it holds only the source *ports* (`dyn RateProviderV1`) and the
+/// fallback policy over them — no transport, registry, or service-locator type.
+/// `#[domain_model]` enforces that at compile time (DE0309).
+#[domain_model]
+pub struct CompositeRateProvider {
+    /// Stable identity of the composite itself (the core gear's configured id) —
+    /// used for log/alarm attribution, never as a rate's provenance.
+    id: String,
+    /// Ordered sources; index 0 is the primary. Guaranteed non-empty by the core gear.
+    sources: Vec<Arc<dyn RateProviderV1>>,
+}
+
+impl CompositeRateProvider {
+    /// Build a composite over an ordered, NON-EMPTY source list.
+    ///
+    /// # Panics
+    /// Only in debug builds, if `sources` is empty — the core gear guarantees
+    /// non-emptiness before constructing (see `discovery.rs::discover`), so this
+    /// is a defensive invariant check. In release, `provider_id()` returns the
+    /// configured id without touching the list and `fetch_latest`/`health`
+    /// degrade to an "empty composite" error.
+    #[must_use]
+    pub fn new(id: String, sources: Vec<Arc<dyn RateProviderV1>>) -> Self {
+        debug_assert!(!sources.is_empty(), "composite requires >= 1 source");
+        Self { id, sources }
+    }
+}
+
+#[async_trait]
+impl RateProviderV1 for CompositeRateProvider {
+    fn provider_id(&self) -> &str {
+        &self.id
+    }
+
+    async fn fetch_latest(
+        &self,
+        ctx: &SecurityContext,
+        pairs: &[CurrencyPair],
+        request_id: &str,
+    ) -> Result<Vec<ProviderRate>, RateProviderError> {
+        let mut last_err: Option<RateProviderError> = None;
+        for source in &self.sources {
+            match source.fetch_latest(ctx, pairs, request_id).await {
+                // As-is: each rate already carries the serving source's id, so
+                // there is nothing for the composite to stamp or record.
+                Ok(doc) => return Ok(doc),
+                Err(e) => {
+                    // Carries `request_id` so every attempt of one tick can be
+                    // collected back together. Only the LAST error reaches the
+                    // caller, so these log lines are the only place the earlier
+                    // sources' failures survive.
+                    tracing::warn!(
+                        source = source.provider_id(),
+                        request_id = request_id,
+                        error = %e,
+                        "bss-rate-provider: source fetch failed; trying the next source"
+                    );
+                    last_err = Some(e);
+                }
+            }
+        }
+        Err(last_err
+            .unwrap_or_else(|| RateProviderError::Internal("composite has no sources".to_owned())))
+    }
+
+    async fn health(
+        &self,
+        ctx: &SecurityContext,
+        request_id: &str,
+    ) -> Result<(), RateProviderError> {
+        let mut last_err: Option<RateProviderError> = None;
+        for source in &self.sources {
+            match source.health(ctx, request_id).await {
+                Ok(()) => return Ok(()),
+                Err(e) => {
+                    tracing::warn!(
+                        source = source.provider_id(),
+                        request_id = request_id,
+                        error = %e,
+                        "bss-rate-provider: source health probe failed; trying the next source"
+                    );
+                    last_err = Some(e);
+                }
+            }
+        }
+        Err(last_err
+            .unwrap_or_else(|| RateProviderError::Internal("composite has no sources".to_owned())))
+    }
+}
+
+#[cfg(test)]
+#[path = "composite_tests.rs"]
+mod tests;

--- a/gears/bss/rate-provider/rate-provider/src/domain/composite_tests.rs
+++ b/gears/bss/rate-provider/rate-provider/src/domain/composite_tests.rs
@@ -1,0 +1,235 @@
+//! Composite fallback + provenance tests with in-memory fake sources.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use bss_ledger_sdk::{CurrencyPair, ProviderRate, RateProviderError, RateProviderV1};
+use chrono::DateTime;
+use toolkit_security::SecurityContext;
+
+use super::CompositeRateProvider;
+
+/// The composite's own configured identity under test.
+const COMPOSITE_ID: &str = "bss-rate-provider";
+
+/// A fake source whose `fetch_latest` and `health` outcomes are set
+/// independently, so the two fallback loops can be exercised in isolation.
+struct Fake {
+    id: &'static str,
+    /// `None` = fetch succeeds; `Some(e)` = fetch fails with `e`.
+    fetch_err: Option<RateProviderError>,
+    /// `None` = health succeeds; `Some(e)` = health fails with `e`.
+    health_err: Option<RateProviderError>,
+}
+
+impl Fake {
+    /// A source where both fetch and health succeed.
+    fn ok(id: &'static str) -> Self {
+        Self {
+            id,
+            fetch_err: None,
+            health_err: None,
+        }
+    }
+
+    /// A source where both fetch and health fail with `err`.
+    fn failing(id: &'static str, err: RateProviderError) -> Self {
+        Self {
+            id,
+            fetch_err: Some(clone_err(&err)),
+            health_err: Some(err),
+        }
+    }
+}
+
+/// `RateProviderError` is not `Clone`, and a `Fake` needs the same failure for
+/// both entry points; rebuild it by variant instead.
+fn clone_err(e: &RateProviderError) -> RateProviderError {
+    match e {
+        RateProviderError::Unreachable(m) => RateProviderError::Unreachable(m.clone()),
+        RateProviderError::UpstreamStatus(s) => RateProviderError::UpstreamStatus(*s),
+        RateProviderError::Internal(m) => RateProviderError::Internal(m.clone()),
+        RateProviderError::InvalidPair(m) => RateProviderError::InvalidPair(m.clone()),
+        RateProviderError::PairUnavailable { base, quote } => RateProviderError::PairUnavailable {
+            base: base.clone(),
+            quote: quote.clone(),
+        },
+    }
+}
+
+#[async_trait]
+impl RateProviderV1 for Fake {
+    fn provider_id(&self) -> &str {
+        self.id
+    }
+
+    async fn fetch_latest(
+        &self,
+        _ctx: &SecurityContext,
+        _pairs: &[CurrencyPair],
+        _request_id: &str,
+    ) -> Result<Vec<ProviderRate>, RateProviderError> {
+        match &self.fetch_err {
+            Some(e) => Err(clone_err(e)),
+            None => Ok(vec![ProviderRate {
+                base: "EUR".to_owned(),
+                quote: "USD".to_owned(),
+                rate_micro: 1_000_000,
+                as_of: DateTime::from_timestamp(1_700_000_000, 0).unwrap(),
+                // Each source stamps its own id — this is what the ledger
+                // records, so the fake must behave like a real source.
+                provider: self.id.to_owned(),
+            }]),
+        }
+    }
+
+    async fn health(
+        &self,
+        _ctx: &SecurityContext,
+        _request_id: &str,
+    ) -> Result<(), RateProviderError> {
+        match &self.health_err {
+            Some(e) => Err(clone_err(e)),
+            None => Ok(()),
+        }
+    }
+}
+
+#[tokio::test]
+async fn falls_back_and_the_served_document_names_the_serving_source() {
+    let composite = CompositeRateProvider::new(
+        COMPOSITE_ID.to_owned(),
+        vec![
+            Arc::new(Fake::failing(
+                "ecb",
+                RateProviderError::Unreachable("down".to_owned()),
+            )),
+            Arc::new(Fake::ok("bank-x")),
+        ],
+    );
+    let ctx = SecurityContext::anonymous();
+    let rates = composite.fetch_latest(&ctx, &[], "req").await.unwrap();
+    assert_eq!(rates.len(), 1);
+    // Provenance rides on the rate itself, so it cannot be raced by another
+    // caller fetching between this fetch and a later `provider_id()` read.
+    assert_eq!(rates[0].provider, "bank-x");
+    // `provider_id()` is the composite's constant identity, NOT the last server.
+    assert_eq!(composite.provider_id(), COMPOSITE_ID);
+}
+
+#[tokio::test]
+async fn all_fail_returns_the_last_sources_error() {
+    // Distinct errors per source, so "returns the FIRST error" cannot pass.
+    let composite = CompositeRateProvider::new(
+        COMPOSITE_ID.to_owned(),
+        vec![
+            Arc::new(Fake::failing(
+                "ecb",
+                RateProviderError::Unreachable("first".to_owned()),
+            )),
+            Arc::new(Fake::failing(
+                "bank-x",
+                RateProviderError::UpstreamStatus(503),
+            )),
+        ],
+    );
+    let ctx = SecurityContext::anonymous();
+    let err = composite.fetch_latest(&ctx, &[], "req").await.unwrap_err();
+    assert!(
+        matches!(err, RateProviderError::UpstreamStatus(503)),
+        "expected the LAST source's error, got {err:?}"
+    );
+    // Identity stays reportable after a total failure, and is never "none" (the
+    // ledger's unconfigured sentinel).
+    assert_eq!(composite.provider_id(), COMPOSITE_ID);
+}
+
+#[tokio::test]
+async fn health_falls_back_to_the_next_source() {
+    // A separate loop from `fetch_latest`'s: a source that cannot serve rates may
+    // still answer a probe, and vice versa.
+    let composite = CompositeRateProvider::new(
+        COMPOSITE_ID.to_owned(),
+        vec![
+            Arc::new(Fake::failing(
+                "ecb",
+                RateProviderError::Unreachable("down".to_owned()),
+            )),
+            Arc::new(Fake::ok("bank-x")),
+        ],
+    );
+    let ctx = SecurityContext::anonymous();
+    assert!(composite.health(&ctx, "req").await.is_ok());
+}
+
+#[tokio::test]
+async fn health_all_fail_returns_the_last_sources_error() {
+    let composite = CompositeRateProvider::new(
+        COMPOSITE_ID.to_owned(),
+        vec![
+            Arc::new(Fake::failing(
+                "ecb",
+                RateProviderError::Unreachable("first".to_owned()),
+            )),
+            Arc::new(Fake::failing(
+                "bank-x",
+                RateProviderError::UpstreamStatus(503),
+            )),
+        ],
+    );
+    let ctx = SecurityContext::anonymous();
+    let err = composite.health(&ctx, "req").await.unwrap_err();
+    assert!(
+        matches!(err, RateProviderError::UpstreamStatus(503)),
+        "expected the LAST source's error, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn health_probes_in_order_and_stops_at_the_first_healthy_source() {
+    // The primary is healthy, so the probe must not fall through to a source
+    // that would fail — proving the loop short-circuits on success.
+    let composite = CompositeRateProvider::new(
+        COMPOSITE_ID.to_owned(),
+        vec![
+            Arc::new(Fake::ok("ecb")),
+            Arc::new(Fake::failing(
+                "bank-x",
+                RateProviderError::Internal("must not be probed".to_owned()),
+            )),
+        ],
+    );
+    let ctx = SecurityContext::anonymous();
+    assert!(composite.health(&ctx, "req").await.is_ok());
+}
+
+#[test]
+fn empty_sources_still_reports_the_configured_identity() {
+    // `CompositeRateProvider::new` debug_asserts non-emptiness, so build the
+    // violating instance directly (this test module is a child of `composite`, so
+    // the private fields are visible) to cover the release-mode case:
+    // `provider_id()` reads no element of the list, so it cannot index out of
+    // bounds.
+    let composite = CompositeRateProvider {
+        id: COMPOSITE_ID.to_owned(),
+        sources: Vec::new(),
+    };
+    assert_eq!(composite.provider_id(), COMPOSITE_ID);
+}
+
+#[tokio::test]
+async fn empty_composite_errors_rather_than_panicking() {
+    let composite = CompositeRateProvider {
+        id: COMPOSITE_ID.to_owned(),
+        sources: Vec::new(),
+    };
+    let ctx = SecurityContext::anonymous();
+    assert!(matches!(
+        composite.fetch_latest(&ctx, &[], "req").await,
+        Err(RateProviderError::Internal(_))
+    ));
+    assert!(matches!(
+        composite.health(&ctx, "req").await,
+        Err(RateProviderError::Internal(_))
+    ));
+}

--- a/gears/bss/rate-provider/rate-provider/src/domain/mod.rs
+++ b/gears/bss/rate-provider/rate-provider/src/domain/mod.rs
@@ -1,0 +1,8 @@
+//! Domain layer — the ordered-fallback policy over the source ports, with no
+//! transport, registry, or service-locator type in its signatures.
+//!
+//! Only [`composite::CompositeRateProvider`] lives here. Source *discovery* is
+//! infrastructure (it talks to the types-registry over the wire and resolves
+//! `ClientHub` entries), so it sits in `crate::infra::discovery` instead.
+
+pub mod composite;

--- a/gears/bss/rate-provider/rate-provider/src/infra/discovery.rs
+++ b/gears/bss/rate-provider/rate-provider/src/infra/discovery.rs
@@ -1,0 +1,299 @@
+//! `DiscoveringRateProvider` — the composite the ledger resolves.
+//!
+//! Lazily discovers the registered source plugins (types-registry instances of
+//! `RateProviderSourcePluginSpecV1`, filtered by vendor), orders them by
+//! `priority` (lower = tried first), resolves each scoped `RateProviderV1` from
+//! `ClientHub`, and delegates ordered fallback to a [`CompositeRateProvider`].
+//!
+//! Discovery re-runs on EVERY `fetch_latest`/`health` call and nothing is cached
+//! between calls, so a source plugin's registration, removal, or `priority`
+//! change takes effect on the very next ledger sync tick with no gear restart.
+//! Cheap enough to do unconditionally: one `list_instances` call plus N in-memory
+//! `ClientHub` lookups, on a background job that ticks hourly by default and
+//! never runs on the posting path.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use bss_ledger_sdk::{CurrencyPair, ProviderRate, RateProviderError, RateProviderV1};
+use bss_rate_provider_sdk::RateProviderSourcePluginSpecV1;
+use toolkit::client_hub::{ClientHub, ClientScope};
+use toolkit::gts::PluginV1;
+use toolkit_security::SecurityContext;
+use types_registry_sdk::{GtsInstance, InstanceQuery, TypesRegistryClient};
+
+use crate::domain::composite::CompositeRateProvider;
+
+/// A `RateProviderV1` that composes the discovered source plugins on demand.
+pub struct DiscoveringRateProvider {
+    hub: Arc<ClientHub>,
+    source_vendor: String,
+    id: String,
+}
+
+/// A source that will take part in the fallback chain.
+struct ChosenSource {
+    /// Lower is tried first.
+    priority: i16,
+    /// The plugin's GTS instance id — the tiebreak when two sources share a
+    /// `priority`. Registry list order is not a stable contract, so ordering on it
+    /// would let the serving source (and the stored provenance) change between
+    /// ticks with no configuration change at all.
+    instance_id: String,
+    client: Arc<dyn RateProviderV1>,
+}
+
+/// One discovery scan: the usable sources, plus the vendors that were filtered
+/// out — carried so an empty result can name what the registry actually held,
+/// not only what was missing.
+struct SourceScan {
+    /// Matching sources, unsorted.
+    chosen: Vec<ChosenSource>,
+    /// Distinct `vendor` values seen on instances dropped by the vendor filter.
+    excluded_vendors: Vec<String>,
+}
+
+impl DiscoveringRateProvider {
+    /// Build over the shared `ClientHub`, the source-plugin vendor filter, and
+    /// this composite's own stable id.
+    #[must_use]
+    pub fn new(hub: Arc<ClientHub>, source_vendor: String, id: String) -> Self {
+        Self {
+            hub,
+            source_vendor,
+            id,
+        }
+    }
+
+    /// Discover source plugins from types-registry, order by priority, and build
+    /// the composite for this call.
+    ///
+    /// # Errors
+    /// [`RateProviderError`] if types-registry is unavailable or no source plugin
+    /// is registered for the configured vendor.
+    async fn discover(&self) -> Result<CompositeRateProvider, RateProviderError> {
+        let registry = self
+            .hub
+            .get::<dyn TypesRegistryClient>()
+            .map_err(|e| RateProviderError::Internal(format!("types-registry unavailable: {e}")))?;
+        let type_id = RateProviderSourcePluginSpecV1::gts_type_id();
+        let instances = registry
+            .list_instances(InstanceQuery::new().with_pattern(format!("{type_id}*")))
+            .await
+            .map_err(|e| {
+                RateProviderError::Unreachable(format!("list rate-provider source plugins: {e}"))
+            })?;
+
+        let scan = self.select_matching_sources(&instances);
+        let mut chosen = scan.chosen;
+        // Instance id as the secondary key, so equal priorities do not fall back
+        // to whatever order `list_instances` happened to return.
+        chosen.sort_by(|a, b| {
+            a.priority
+                .cmp(&b.priority)
+                .then_with(|| a.instance_id.cmp(&b.instance_id))
+        });
+        warn_on_duplicate_priorities(&chosen);
+
+        let sources: Vec<Arc<dyn RateProviderV1>> = chosen.into_iter().map(|c| c.client).collect();
+        if sources.is_empty() {
+            return Err(RateProviderError::Unreachable(no_sources_message(
+                &self.source_vendor,
+                instances.len(),
+                &scan.excluded_vendors,
+            )));
+        }
+        Ok(CompositeRateProvider::new(self.id.clone(), sources))
+    }
+
+    /// Deserialize each instance as a typed `PluginV1` to read its `vendor` and
+    /// `priority`, keep the matching-vendor sources, and resolve their scoped
+    /// clients.
+    ///
+    /// Typed rather than ad-hoc `serde_json::Value` field pokes: this and the
+    /// ledger's own `toolkit::plugins::choose_plugin_instance` consume the same
+    /// wire format, so reading it through the same struct keeps the two from
+    /// drifting, and a format change surfaces as a logged per-instance anomaly
+    /// instead of silently filtering every source out.
+    ///
+    /// Nothing here is fatal on its own — a malformed instance, a vendor mismatch,
+    /// or a vendor match with no scoped client is logged and excluded. `discover`
+    /// reports a failure only if that empties the whole set.
+    fn select_matching_sources(&self, instances: &[GtsInstance]) -> SourceScan {
+        let mut chosen = Vec::new();
+        let mut excluded_vendors: Vec<String> = Vec::new();
+        for inst in instances {
+            match self.classify(inst) {
+                Candidate::Source(priority, src) => chosen.push(ChosenSource {
+                    priority,
+                    instance_id: inst.id.as_ref().to_owned(),
+                    client: src,
+                }),
+                // Deduplicated: N plugins under one wrong vendor should read as
+                // one wrong vendor in the error, not as N repetitions.
+                Candidate::OtherVendor(vendor) => {
+                    if !excluded_vendors.contains(&vendor) {
+                        excluded_vendors.push(vendor);
+                    }
+                }
+                Candidate::Excluded => {}
+            }
+        }
+        SourceScan {
+            chosen,
+            excluded_vendors,
+        }
+    }
+
+    /// Decide what a single registry instance contributes to the scan, logging
+    /// each exclusion at the point it is detected.
+    fn classify(&self, inst: &GtsInstance) -> Candidate {
+        let Some(spec) = parse_spec(inst) else {
+            return Candidate::Excluded;
+        };
+        if spec.vendor != self.source_vendor {
+            log_vendor_mismatch(inst, &spec.vendor, &self.source_vendor);
+            return Candidate::OtherVendor(spec.vendor);
+        }
+        self.resolve_scoped(inst, spec.priority)
+    }
+
+    /// Look up the scoped `RateProviderV1` published alongside this instance.
+    ///
+    /// A published instance with no client is the partial-registration state a
+    /// plugin is briefly in during startup — excluded, not fatal, so a healthy
+    /// sibling still serves this tick and the next tick can pick it up.
+    fn resolve_scoped(&self, inst: &GtsInstance, priority: i16) -> Candidate {
+        let scope = ClientScope::gts_id(inst.id.as_ref());
+        if let Some(src) = self.hub.try_get_scoped::<dyn RateProviderV1>(&scope) {
+            Candidate::Source(priority, src)
+        } else {
+            tracing::warn!(
+                instance_id = %inst.id.as_ref(),
+                "bss-rate-provider: source plugin instance has no scoped RateProviderV1 \
+                 client registered; excluding it from the fallback chain"
+            );
+            Candidate::Excluded
+        }
+    }
+}
+
+/// Read the instance's typed `PluginV1` envelope, or log and yield `None`.
+fn parse_spec(inst: &GtsInstance) -> Option<PluginV1<RateProviderSourcePluginSpecV1>> {
+    match serde_json::from_value(inst.object.clone()) {
+        Ok(spec) => Some(spec),
+        Err(e) => {
+            tracing::warn!(
+                instance_id = %inst.id.as_ref(),
+                error = %e,
+                "bss-rate-provider: source plugin instance does not deserialize as PluginV1; \
+                 excluding it from the fallback chain"
+            );
+            None
+        }
+    }
+}
+
+/// Record a vendor-filtered instance.
+///
+/// Not an anomaly on its own: one registry can hold source plugins belonging to
+/// another composite. `debug`, not `warn`, because discovery re-runs every tick,
+/// so a warning per foreign instance per tick would be pure noise. It is still
+/// logged (and the vendor still travels back to the caller) because a `vendor`
+/// typo passes every startup check by design — discovery is lazy, so plugin
+/// registration order never has to be enforced — leaving this the only place the
+/// mismatch is visible.
+fn log_vendor_mismatch(inst: &GtsInstance, vendor: &str, expected: &str) {
+    tracing::debug!(
+        instance_id = %inst.id.as_ref(),
+        vendor,
+        expected_vendor = expected,
+        "bss-rate-provider: source plugin instance advertises a different vendor; \
+         excluding it from the fallback chain"
+    );
+}
+
+/// What one registry instance contributes to a scan.
+enum Candidate {
+    /// A usable source, to be ordered by its `priority`.
+    Source(i16, Arc<dyn RateProviderV1>),
+    /// Dropped by the vendor filter; carries the `vendor` it advertised, which
+    /// is the one exclusion reason worth reporting back to the caller.
+    OtherVendor(String),
+    /// Dropped for a reason already logged where it was detected.
+    Excluded,
+}
+
+/// Spell out what the scan saw when it found nothing usable.
+///
+/// The `vendor` string has to agree in three independently configured places —
+/// this gear's `source_vendor`, each source plugin's `vendor`, and the ledger's
+/// `fx.provider_vendor`. A typo in any of them fails no startup check, so it
+/// first surfaces here, on the ledger's first rate-sync tick. Naming the expected
+/// vendor and the ones actually present makes that a one-line diagnosis.
+fn no_sources_message(
+    expected: &str,
+    instances_seen: usize,
+    excluded_vendors: &[String],
+) -> String {
+    if excluded_vendors.is_empty() {
+        format!(
+            "no FX rate-provider source plugins registered for vendor {expected:?} \
+             ({instances_seen} source-plugin instance(s) in the types-registry)"
+        )
+    } else {
+        let found = excluded_vendors.join(", ");
+        format!(
+            "no FX rate-provider source plugins registered for vendor {expected:?}; \
+             of {instances_seen} source-plugin instance(s) in the types-registry, none \
+             matched — vendors present: {found}. Check that this gear's `source_vendor` \
+             equals each source plugin's `vendor`."
+        )
+    }
+}
+
+/// A duplicate `priority` doesn't fail discovery — the instance-id tiebreak keeps
+/// the order deterministic — but it is logged, because which tied source serves is
+/// then decided by an id nobody chose for that purpose. `chosen` must already be
+/// sorted.
+fn warn_on_duplicate_priorities(chosen: &[ChosenSource]) {
+    for pair in chosen.windows(2) {
+        if pair[0].priority == pair[1].priority {
+            tracing::warn!(
+                priority = pair[0].priority,
+                first = %pair[0].instance_id,
+                second = %pair[1].instance_id,
+                "bss-rate-provider: two or more source plugins share the same priority; \
+                 order among them falls back to instance id. Set distinct priorities to \
+                 choose it deliberately"
+            );
+        }
+    }
+}
+
+#[async_trait]
+impl RateProviderV1 for DiscoveringRateProvider {
+    fn provider_id(&self) -> &str {
+        &self.id
+    }
+
+    async fn fetch_latest(
+        &self,
+        ctx: &SecurityContext,
+        pairs: &[CurrencyPair],
+        request_id: &str,
+    ) -> Result<Vec<ProviderRate>, RateProviderError> {
+        self.discover()
+            .await?
+            .fetch_latest(ctx, pairs, request_id)
+            .await
+    }
+
+    async fn health(
+        &self,
+        ctx: &SecurityContext,
+        request_id: &str,
+    ) -> Result<(), RateProviderError> {
+        self.discover().await?.health(ctx, request_id).await
+    }
+}

--- a/gears/bss/rate-provider/rate-provider/src/infra/mod.rs
+++ b/gears/bss/rate-provider/rate-provider/src/infra/mod.rs
@@ -1,0 +1,8 @@
+//! Infrastructure layer — source-plugin discovery.
+//!
+//! [`discovery::DiscoveringRateProvider`] is the adapter the gear registers: it
+//! queries the types-registry over the wire, resolves scoped `ClientHub` clients,
+//! and hands the resulting ordered ports to the domain layer's
+//! [`crate::domain::composite::CompositeRateProvider`] to apply the fallback policy.
+
+pub mod discovery;

--- a/gears/bss/rate-provider/rate-provider/src/lib.rs
+++ b/gears/bss/rate-provider/rate-provider/src/lib.rs
@@ -1,0 +1,15 @@
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+//! `bss-rate-provider` — the core FX rate-provider gear.
+//!
+//! Discovers the registered source plugins (`bss-rate-provider-ecb-plugin`,
+//! `bss-rate-provider-http-json-plugin`, …), orders them by `priority`, and
+//! composes them with ordered fallback
+//! ([`domain::composite::CompositeRateProvider`]). It re-registers that composite
+//! as a `PluginV1` instance the ledger discovers (a scoped
+//! [`bss_ledger_sdk::RateProviderV1`] keyed by its GTS instance id), so a
+//! provider outage never touches the posting path — see `docs/DESIGN.md`.
+
+pub mod config;
+pub mod domain;
+pub mod infra;
+pub mod module;

--- a/gears/bss/rate-provider/rate-provider/src/module.rs
+++ b/gears/bss/rate-provider/rate-provider/src/module.rs
@@ -1,0 +1,94 @@
+//! `BssRateProviderGear` — the core gear.
+//!
+//! Registers a [`crate::infra::discovery::DiscoveringRateProvider`] (which composes the
+//! discovered source plugins) as a `PluginV1<RateProviderPluginSpecV1>` instance
+//! in the types-registry plus a scoped `RateProviderV1` client keyed by the GTS
+//! instance id. The ledger discovers this instance each rate-sync tick. Absent
+//! from the `gears:` config block => inert (the ledger keeps its fail-safe
+//! `UnconfiguredRateProviderV1` default, no alarm).
+
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use bss_ledger_sdk::{RateProviderPluginSpecV1, RateProviderV1};
+use bss_rate_provider_sdk::registration::register_rate_provider_plugin;
+use toolkit::Gear;
+use toolkit::config::ConfigError;
+use toolkit::context::GearCtx;
+use tracing::info;
+
+use crate::config::RateProviderConfig;
+use crate::infra::discovery::DiscoveringRateProvider;
+
+/// Stable GTS instance segment appended to the composite plugin type id. Must be
+/// a single valid GTS segment (`vendor.name.plugin.vN`, 5 dot-components).
+const INSTANCE_SEGMENT: &str = "cf.bss.rate_provider_composite.plugin.v1";
+
+/// The core FX rate-provider gear.
+#[toolkit::gear(name = "bss-rate-provider", deps = [types_registry])]
+pub struct BssRateProviderGear;
+
+impl Default for BssRateProviderGear {
+    fn default() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl Gear for BssRateProviderGear {
+    async fn init(&self, ctx: &GearCtx) -> Result<()> {
+        // Config gate: absent => inert (fail-safe, the ledger uses its default and
+        // does not alarm); present-but-empty => defaults; invalid => abort loudly.
+        let cfg: RateProviderConfig = match ctx.config::<RateProviderConfig>() {
+            Ok(cfg) => cfg,
+            Err(ConfigError::MissingConfigSection { .. }) => RateProviderConfig::default(),
+            Err(ConfigError::GearNotFound { .. }) => {
+                info!("bss-rate-provider: not configured; the ledger keeps its fail-safe default");
+                return Ok(());
+            }
+            Err(e) => return Err(e).context("bss-rate-provider: invalid config"),
+        };
+
+        // The composite discovers + composes the source plugins lazily on first
+        // fetch (serve phase — all plugins registered), sharing the process hub.
+        let provider: Arc<dyn RateProviderV1> = Arc::new(DiscoveringRateProvider::new(
+            ctx.client_hub(),
+            cfg.source_vendor.clone(),
+            cfg.id.clone(),
+        ));
+
+        // Publish the composite as a plugin instance the ledger discovers.
+        let instance_id = register_rate_provider_plugin::<RateProviderPluginSpecV1>(
+            ctx,
+            INSTANCE_SEGMENT,
+            cfg.vendor.clone(),
+            cfg.priority,
+            provider,
+        )
+        .await?;
+
+        info!(
+            vendor = %cfg.vendor,
+            instance_id = %instance_id,
+            "bss-rate-provider: registered composite rate-provider plugin"
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod gts_id_tests {
+    use bss_ledger_sdk::RateProviderPluginSpecV1;
+    use bss_rate_provider_sdk::registration::assert_registration_builds_valid_gts_id;
+
+    /// The built composite plugin instance id must parse as a valid GTS id.
+    #[test]
+    fn instance_id_parses_as_gts() {
+        assert_registration_builds_valid_gts_id::<RateProviderPluginSpecV1>(
+            super::INSTANCE_SEGMENT,
+            "cf.bss",
+            100,
+        );
+    }
+}

--- a/gears/bss/rate-provider/rate-provider/tests/discovery.rs
+++ b/gears/bss/rate-provider/rate-provider/tests/discovery.rs
@@ -1,0 +1,443 @@
+//! Integration: the core gear's `DiscoveringRateProvider` over a real
+//! `ClientHub` + an in-memory types-registry mock.
+//!
+//! Covers the whole discovery path: list source-plugin instances → filter by
+//! vendor → order by `priority` → resolve scoped `RateProviderV1` → compose
+//! (ordered fallback + per-rate provenance), plus the empty-set error and the
+//! per-call re-discovery that picks up a late-registered plugin without a restart.
+#![allow(
+    clippy::unwrap_used,
+    reason = "integration-test setup helpers: an unwrap here just fails the test"
+)]
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use bss_ledger_sdk::{CurrencyPair, ProviderRate, RateProviderError, RateProviderV1};
+use bss_rate_provider::infra::discovery::DiscoveringRateProvider;
+use bss_rate_provider_sdk::RateProviderSourcePluginSpecV1;
+use chrono::DateTime;
+use toolkit::client_hub::{ClientHub, ClientScope};
+use toolkit::gts::PluginV1;
+use toolkit_security::SecurityContext;
+use types_registry_sdk::TypesRegistryClient;
+use types_registry_sdk::models::GtsInstance;
+use types_registry_sdk::testing::{MockTypesRegistryClient, make_test_instance};
+
+/// The core gear's own configured id (what `provider_id()` reports).
+const COMPOSITE_ID: &str = "bss-rate-provider";
+
+/// A source whose `provider_id` is `id` and which succeeds or fails per `ok`.
+struct FakeSource {
+    id: String,
+    ok: bool,
+}
+
+#[async_trait]
+impl RateProviderV1 for FakeSource {
+    fn provider_id(&self) -> &str {
+        &self.id
+    }
+    async fn fetch_latest(
+        &self,
+        _ctx: &SecurityContext,
+        _pairs: &[CurrencyPair],
+        _request_id: &str,
+    ) -> Result<Vec<ProviderRate>, RateProviderError> {
+        if self.ok {
+            Ok(vec![ProviderRate {
+                base: "EUR".to_owned(),
+                quote: "USD".to_owned(),
+                rate_micro: 1_000_000,
+                as_of: DateTime::from_timestamp(1_700_000_000, 0).unwrap(),
+                // Real sources stamp their own id; the fake must too, since
+                // that is the provenance the ledger stores.
+                provider: self.id.clone(),
+            }])
+        } else {
+            Err(RateProviderError::Unreachable("down".to_owned()))
+        }
+    }
+
+    /// Reachability tracks the same `ok` flag as the fetch, so one `SourceSpec` can
+    /// express "this source is down" for both calls. A real source's probe is
+    /// independent of its fetch.
+    async fn health(
+        &self,
+        _ctx: &SecurityContext,
+        _request_id: &str,
+    ) -> Result<(), RateProviderError> {
+        if self.ok {
+            Ok(())
+        } else {
+            Err(RateProviderError::Unreachable("down".to_owned()))
+        }
+    }
+}
+
+/// One configured source for a test.
+struct SourceSpec<'a> {
+    /// Both the plugin's instance segment and the `provider_id` it reports.
+    name: &'a str,
+    vendor: &'a str,
+    priority: i16,
+    /// Whether its `fetch_latest` succeeds.
+    ok: bool,
+    /// When false, the `PluginV1` instance is published in the registry but NO
+    /// scoped `ClientHub` client is registered — the partial-registration state a
+    /// plugin is briefly in during startup.
+    register_client: bool,
+}
+
+impl<'a> SourceSpec<'a> {
+    /// A fully-registered, healthy source.
+    fn ok(name: &'a str, vendor: &'a str, priority: i16) -> Self {
+        Self {
+            name,
+            vendor,
+            priority,
+            ok: true,
+            register_client: true,
+        }
+    }
+
+    /// A fully-registered source whose fetches fail.
+    fn failing(name: &'a str, vendor: &'a str, priority: i16) -> Self {
+        Self {
+            ok: false,
+            ..Self::ok(name, vendor, priority)
+        }
+    }
+
+    /// Instance published, scoped client absent.
+    fn instance_only(name: &'a str, vendor: &'a str, priority: i16) -> Self {
+        Self {
+            register_client: false,
+            ..Self::ok(name, vendor, priority)
+        }
+    }
+}
+
+/// The wiring under test plus the handles a test needs to poke it mid-run.
+struct Harness {
+    provider: DiscoveringRateProvider,
+    mock: Arc<MockTypesRegistryClient>,
+    hub: Arc<ClientHub>,
+}
+
+/// Build the `PluginV1` registration pair for a source, deterministically from
+/// its name — so a test can register the scoped client later, out of band.
+fn registration(spec: &SourceSpec<'_>) -> (String, serde_json::Value) {
+    let segment = format!("cf.bss.rate_provider_{}.plugin.v1", spec.name);
+    let (id, json) = PluginV1::<RateProviderSourcePluginSpecV1>::build_registration(
+        &segment,
+        spec.vendor,
+        spec.priority,
+    )
+    .unwrap();
+    (id.as_ref().to_owned(), json)
+}
+
+/// Register `spec`'s scoped `RateProviderV1` client on `hub` under its instance id.
+fn register_scoped_client(hub: &ClientHub, spec: &SourceSpec<'_>) {
+    let (id_str, _json) = registration(spec);
+    let source: Arc<dyn RateProviderV1> = Arc::new(FakeSource {
+        id: spec.name.to_owned(),
+        ok: spec.ok,
+    });
+    hub.register_scoped::<dyn RateProviderV1>(ClientScope::gts_id(&id_str), source);
+}
+
+/// Build a `ClientHub` with the given sources registered scoped + a mock
+/// types-registry listing their `PluginV1` instances.
+fn setup(sources: &[SourceSpec<'_>], discover_vendor: &str) -> Harness {
+    build(sources, Vec::new(), false, discover_vendor)
+}
+
+/// Full harness builder.
+///
+/// `extra_instances` are published verbatim alongside the `sources`, for registry
+/// contents a `SourceSpec` cannot express (an instance whose object is not a
+/// `PluginV1` envelope). `registry_unreachable` makes every `list_*` call fail,
+/// standing in for a types-registry outage.
+fn build(
+    sources: &[SourceSpec<'_>],
+    extra_instances: Vec<GtsInstance>,
+    registry_unreachable: bool,
+    discover_vendor: &str,
+) -> Harness {
+    let hub = Arc::new(ClientHub::default());
+    let mut instances: Vec<GtsInstance> = Vec::new();
+    for spec in sources {
+        let (id_str, json) = registration(spec);
+        if spec.register_client {
+            register_scoped_client(&hub, spec);
+        }
+        instances.push(make_test_instance(&id_str, json));
+    }
+    instances.extend(extra_instances);
+    let mut mock = MockTypesRegistryClient::new().with_instances(instances);
+    if registry_unreachable {
+        mock = mock.with_list_error(types_registry_sdk::testing::internal(
+            "types-registry is down",
+        ));
+    }
+    let mock = Arc::new(mock);
+    hub.register::<dyn TypesRegistryClient>(mock.clone());
+    let provider = DiscoveringRateProvider::new(
+        Arc::clone(&hub),
+        discover_vendor.to_owned(),
+        COMPOSITE_ID.to_owned(),
+    );
+    Harness {
+        provider,
+        mock,
+        hub,
+    }
+}
+
+#[tokio::test]
+async fn composes_in_priority_order_and_stamps_the_serving_source() {
+    let h = setup(
+        &[
+            SourceSpec::ok("ecb", "cf.bss", 100),
+            SourceSpec::ok("bank", "cf.bss", 200),
+        ],
+        "cf.bss",
+    );
+    let ctx = SecurityContext::anonymous();
+    let rates = h.provider.fetch_latest(&ctx, &[], "req").await.unwrap();
+    assert_eq!(rates.len(), 1);
+    // Lowest priority (100 = ecb) is tried first and succeeds, and says so on the
+    // rate itself.
+    assert_eq!(rates[0].provider, "ecb");
+    // The adapter's own identity is constant, not "whoever served last".
+    assert_eq!(h.provider.provider_id(), COMPOSITE_ID);
+}
+
+#[tokio::test]
+async fn falls_back_to_next_priority_on_failure() {
+    let h = setup(
+        &[
+            SourceSpec::failing("ecb", "cf.bss", 100),
+            SourceSpec::ok("bank", "cf.bss", 200),
+        ],
+        "cf.bss",
+    );
+    let ctx = SecurityContext::anonymous();
+    let rates = h.provider.fetch_latest(&ctx, &[], "req").await.unwrap();
+    assert_eq!(rates.len(), 1);
+    // The primary failed, so the fallback served — and the stored provenance says
+    // so.
+    assert_eq!(rates[0].provider, "bank");
+}
+
+#[tokio::test]
+async fn filters_out_other_vendor_sources() {
+    // The rogue source has a LOWER priority (tried first if included) but a
+    // different vendor, so it must be excluded and ecb must serve.
+    let h = setup(
+        &[
+            SourceSpec::ok("ecb", "cf.bss", 100),
+            SourceSpec::ok("rogue", "other", 10),
+        ],
+        "cf.bss",
+    );
+    let ctx = SecurityContext::anonymous();
+    let rates = h.provider.fetch_latest(&ctx, &[], "req").await.unwrap();
+    assert_eq!(rates[0].provider, "ecb");
+}
+
+#[tokio::test]
+async fn equal_priorities_resolve_the_same_way_whatever_the_registry_order() {
+    // Registry list order is not a stable contract, so if it decided ties the
+    // provenance written onto financial rows could change between ticks with no
+    // configuration change. The instance-id tiebreak pins it:
+    // "…rate_provider_bank…" sorts before "…rate_provider_ecb…".
+    let ctx = SecurityContext::anonymous();
+    for order in [["ecb", "bank"], ["bank", "ecb"]] {
+        let h = setup(
+            &[
+                SourceSpec::ok(order[0], "cf.bss", 100),
+                SourceSpec::ok(order[1], "cf.bss", 100),
+            ],
+            "cf.bss",
+        );
+        let rates = h.provider.fetch_latest(&ctx, &[], "req").await.unwrap();
+        assert_eq!(
+            rates[0].provider, "bank",
+            "registry order {order:?} changed which tied source served"
+        );
+    }
+}
+
+#[tokio::test]
+async fn errors_when_no_matching_vendor_source() {
+    let h = setup(&[SourceSpec::ok("ecb", "other", 100)], "cf.bss");
+    let ctx = SecurityContext::anonymous();
+    let err = h.provider.fetch_latest(&ctx, &[], "req").await.unwrap_err();
+    // A `vendor` typo passes every startup check, so this first-tick error is the
+    // only place it can be diagnosed: it must name the wanted vendor AND the ones
+    // actually registered, or the operator is left comparing YAML against a
+    // registry they cannot see.
+    let msg = err.to_string();
+    assert!(
+        msg.contains("cf.bss"),
+        "expected vendor missing from: {msg}"
+    );
+    assert!(
+        msg.contains("other"),
+        "vendor present in the registry missing from: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn errors_when_the_registry_holds_no_source_plugins_at_all() {
+    // The other arm of the same message: nothing to list means there is no
+    // vendor to compare against, so the error must not imply a mismatch.
+    let h = setup(&[], "cf.bss");
+    let ctx = SecurityContext::anonymous();
+    let err = h.provider.fetch_latest(&ctx, &[], "req").await.unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("cf.bss"),
+        "expected vendor missing from: {msg}"
+    );
+    assert!(
+        !msg.contains("vendors present"),
+        "no instances were registered, so none can be listed: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn instance_without_a_scoped_client_is_excluded_not_fatal() {
+    // Partial registration of one source must not take down a healthy other.
+    let h = setup(
+        &[
+            SourceSpec::instance_only("ecb", "cf.bss", 100),
+            SourceSpec::ok("bank", "cf.bss", 200),
+        ],
+        "cf.bss",
+    );
+    let ctx = SecurityContext::anonymous();
+    let rates = h.provider.fetch_latest(&ctx, &[], "req").await.unwrap();
+    assert_eq!(rates[0].provider, "bank");
+}
+
+#[tokio::test]
+async fn discovery_reruns_every_tick_so_priority_changes_take_effect_without_restart() {
+    let h = setup(&[SourceSpec::ok("ecb", "cf.bss", 100)], "cf.bss");
+    let ctx = SecurityContext::anonymous();
+    h.provider.fetch_latest(&ctx, &[], "req").await.unwrap();
+    h.provider.fetch_latest(&ctx, &[], "req").await.unwrap();
+    // Never cached across calls: a second fetch re-lists instances, so a plugin
+    // that registers, deregisters, or changes `priority` is picked up on the very
+    // next tick, not only after a restart.
+    assert_eq!(h.mock.list_instance_calls(), 2);
+}
+
+#[tokio::test]
+async fn a_failed_tick_self_heals_once_the_source_finishes_registering() {
+    // The late-registration race: the plugin published its PluginV1 instance but
+    // not yet its scoped client, so the first tick finds nothing usable. Nothing
+    // about that failure is cached, so the next tick succeeds with no restart.
+    let spec = SourceSpec::instance_only("ecb", "cf.bss", 100);
+    let h = setup(&[spec], "cf.bss");
+    let ctx = SecurityContext::anonymous();
+
+    assert!(
+        h.provider.fetch_latest(&ctx, &[], "req").await.is_err(),
+        "no usable source yet, so this tick must fail"
+    );
+
+    register_scoped_client(&h.hub, &SourceSpec::ok("ecb", "cf.bss", 100));
+
+    let rates = h.provider.fetch_latest(&ctx, &[], "req").await.unwrap();
+    assert_eq!(rates[0].provider, "ecb");
+    assert_eq!(
+        h.mock.list_instance_calls(),
+        2,
+        "the retry must re-query the registry, not reuse a cached failure"
+    );
+}
+
+#[tokio::test]
+async fn concurrent_first_fetches_each_discover_independently() {
+    let h = setup(&[SourceSpec::ok("ecb", "cf.bss", 100)], "cf.bss");
+    let ctx = SecurityContext::anonymous();
+
+    // Discovery is not cached, so two concurrent callers each run their own pass.
+    let (a, b) = tokio::join!(
+        h.provider.fetch_latest(&ctx, &[], "req-a"),
+        h.provider.fetch_latest(&ctx, &[], "req-b")
+    );
+    a.unwrap();
+    b.unwrap();
+    assert_eq!(h.mock.list_instance_calls(), 2);
+}
+
+#[tokio::test]
+async fn an_unreachable_registry_fails_the_tick_instead_of_reporting_no_sources() {
+    // Discovery cannot run at all, which is a different fault from "the registry
+    // answered and held nothing usable": the sources may be perfectly healthy. It
+    // must surface as an error the ledger alarms on, never as an empty success that
+    // would look like a served tick with no rates.
+    let h = build(
+        &[SourceSpec::ok("ecb", "cf.bss", 100)],
+        Vec::new(),
+        true,
+        "cf.bss",
+    );
+    let ctx = SecurityContext::anonymous();
+    let err = h.provider.fetch_latest(&ctx, &[], "req").await.unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        matches!(err, RateProviderError::Unreachable(_)),
+        "a registry outage must be Unreachable, got {err:?}"
+    );
+    assert!(
+        msg.contains("list rate-provider source plugins"),
+        "the error must say the listing failed, not imply a vendor mismatch: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn an_instance_that_is_not_a_plugin_envelope_is_excluded_not_fatal() {
+    // A registry entry under this gear's own type prefix whose object does not
+    // deserialize as `PluginV1`: a stale entry from an older format, or another
+    // gear publishing a lookalike. It must be dropped, not taken down the whole
+    // chain — and not silently demoted to a default priority either, which is why
+    // the healthy source has the HIGHER priority number and must still serve.
+    let broken = SourceSpec::ok("broken", "cf.bss", 10);
+    let (broken_id, _json) = registration(&broken);
+    let h = build(
+        &[SourceSpec::ok("ecb", "cf.bss", 100)],
+        vec![make_test_instance(
+            &broken_id,
+            serde_json::json!({ "unexpected": true }),
+        )],
+        false,
+        "cf.bss",
+    );
+    let ctx = SecurityContext::anonymous();
+    let rates = h.provider.fetch_latest(&ctx, &[], "req").await.unwrap();
+    assert_eq!(
+        rates[0].provider, "ecb",
+        "the healthy source must serve despite the unparseable sibling"
+    );
+}
+
+#[tokio::test]
+async fn health_probes_the_discovered_sources() {
+    let h = setup(
+        &[
+            SourceSpec::failing("ecb", "cf.bss", 100),
+            SourceSpec::ok("bank", "cf.bss", 200),
+        ],
+        "cf.bss",
+    );
+    let ctx = SecurityContext::anonymous();
+    // The composite probes in priority order and short-circuits on the first
+    // reachable source: ecb is down, bank answers, so the composite is reachable.
+    assert!(h.provider.health(&ctx, "req").await.is_ok());
+}


### PR DESCRIPTION
fx (foreign exchange) rate provider
docs(bss): fx rate provider module

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a plugin-based FX rate-provider subsystem with ECB and HTTP/JSON sources and vendor-based, priority-ordered fallback.
  * Implemented per-tick lazy discovery and a composite provider model, with HTTPS-only outbound fetching and fetch/health instrumentation.
* **Bug Fixes**
  * Improved ledger FX rate attribution to persist true per-rate provider provenance under concurrent rate-sync processing.
* **Documentation**
  * Added design and PRD documentation, plus E2E enablement notes for the new subsystem.
* **Tests**
  * Added extensive unit/integration coverage for discovery, parsing/mapping, auth/config validation, and deterministic rate conversion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->